### PR TITLE
Do not ommit labels, descriptions, aliases and sitelinks keys when empty arrays

### DIFF
--- a/src/Serializers/EntitySerializer.php
+++ b/src/Serializers/EntitySerializer.php
@@ -96,19 +96,11 @@ abstract class EntitySerializer implements DispatchableSerializer {
 	private function addLabelsToSerialization( Entity $entity, array &$serialization ) {
 		$labels = $entity->getLabels();
 
-		if ( count( $labels ) === 0 ) {
-			return;
-		}
-
 		$serialization['labels'] = $this->serializeValuePerLanguageArray( $labels );
 	}
 
 	private function addDescriptionsToSerialization( Entity $entity, array &$serialization ) {
 		$descriptions = $entity->getDescriptions();
-
-		if ( count( $descriptions ) === 0 ) {
-			return;
-		}
 
 		$serialization['descriptions'] = $this->serializeValuePerLanguageArray( $descriptions );
 	}
@@ -129,10 +121,6 @@ abstract class EntitySerializer implements DispatchableSerializer {
 
 	private function addAliasesToSerialization( Entity $entity, array &$serialization ) {
 		$aliases = $entity->getAllAliases();
-
-		if ( count( $aliases ) === 0 ) {
-			return;
-		}
 
 		$serialization['aliases'] = $this->serializeValuesPerLanguageArray( $aliases );
 	}

--- a/src/Serializers/ItemSerializer.php
+++ b/src/Serializers/ItemSerializer.php
@@ -51,9 +51,7 @@ class ItemSerializer extends EntitySerializer {
 	private function addSiteLinksToSerialization( Item $item, array &$serialization ) {
 		$siteLinks = $item->getSiteLinks();
 
-		if ( count( $siteLinks ) === 0 ) {
-			return;
-		}
+		$serialization['sitelinks'] = array();
 
 		foreach( $siteLinks as $siteLink ) {
 			$serialization['sitelinks'][$siteLink->getSiteId()] = $this->siteLinkSerializer->serialize( $siteLink );

--- a/tests/unit/Serializers/EntitySerializerTest.php
+++ b/tests/unit/Serializers/EntitySerializerTest.php
@@ -75,7 +75,10 @@ class EntitySerializerTest extends SerializerBaseTest {
 
 		$argumentLists[] = array(
 			array(
-				'type' => 'item'
+				'type' => 'item',
+				'labels' => array(),
+				'descriptions' => array(),
+				'aliases' => array(),
 			),
 			Item::newEmpty()
 		);
@@ -85,7 +88,10 @@ class EntitySerializerTest extends SerializerBaseTest {
 		$argumentLists[] = array(
 			array(
 				'type' => 'item',
-				'id' => 'Q42'
+				'id' => 'Q42',
+				'labels' => array(),
+				'descriptions' => array(),
+				'aliases' => array(),
 			),
 			$entity
 		);
@@ -107,7 +113,9 @@ class EntitySerializerTest extends SerializerBaseTest {
 						'language' => 'fr',
 						'value' => 'Nyan Cat'
 					)
-				)
+				),
+				'descriptions' => array(),
+				'aliases' => array(),
 			),
 			$entity
 		);
@@ -129,7 +137,9 @@ class EntitySerializerTest extends SerializerBaseTest {
 						'language' => 'fr',
 						'value' => 'A Nyan Cat'
 					)
-				)
+				),
+				'labels' => array(),
+				'aliases' => array(),
 			),
 			$entity
 		);
@@ -157,7 +167,9 @@ class EntitySerializerTest extends SerializerBaseTest {
 							'value' => 'Cat'
 						)
 					)
-				)
+				),
+				'labels' => array(),
+				'descriptions' => array(),
 			),
 			$entity
 		);
@@ -180,7 +192,10 @@ class EntitySerializerTest extends SerializerBaseTest {
 							'rank' => 'normal'
 						)
 					)
-				)
+				),
+				'labels' => array(),
+				'descriptions' => array(),
+				'aliases' => array(),
 			),
 			$entity
 		);

--- a/tests/unit/Serializers/ItemSerializerTest.php
+++ b/tests/unit/Serializers/ItemSerializerTest.php
@@ -57,7 +57,11 @@ class ItemSerializerTest extends SerializerBaseTest {
 		$provider = array(
 			array(
 				array(
-					'type' => 'item'
+					'type' => 'item',
+					'labels' => array(),
+					'descriptions' => array(),
+					'aliases' => array(),
+					'sitelinks' => array(),
 				),
 				Item::newEmpty()
 			),
@@ -74,7 +78,10 @@ class ItemSerializerTest extends SerializerBaseTest {
 						'title' => 'Nyan Cat',
 						'badges' => array()
 					)
-				)
+				),
+				'labels' => array(),
+				'descriptions' => array(),
+				'aliases' => array(),
 			),
 			$item
 		);

--- a/tests/unit/Serializers/PropertySerializerTest.php
+++ b/tests/unit/Serializers/PropertySerializerTest.php
@@ -50,7 +50,10 @@ class PropertySerializerTest extends SerializerBaseTest {
 			array(
 				array(
 					'type' => 'property',
-					'datatype' => 'string'
+					'datatype' => 'string',
+					'labels' => array(),
+					'descriptions' => array(),
+					'aliases' => array(),
 				),
 				$property
 			),


### PR DESCRIPTION
Solves part of #67
