### PR TITLE
Create StatementSerializer and StatementDeserializer

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -67,6 +67,15 @@ class DeserializerFactory {
 		return new SiteLinkDeserializer( $this->newEntityIdDeserializer() );
 	}
 
+	/**
+	 * Returns a Deserializer that can deserialize Statement objects.
+	 *
+	 * @return Deserializer
+	 */
+	public function newStatementDeserializer() {
+		return new Deserializers\StatementDeserializer( $this->newClaimDeserializer(), $this->newReferenceDeserializer() );
+	}
+
 	/*
 	 * Returns a Deserializer that can deserialize Claims objects.
 	 *
@@ -82,11 +91,7 @@ class DeserializerFactory {
 	 * @return DispatchableDeserializer
 	 */
 	public function newClaimDeserializer() {
-		return new ClaimDeserializer(
-			$this->newSnakDeserializer(),
-			$this->newSnaksDeserializer(),
-			$this->newReferencesDeserializer()
-		);
+		return new ClaimDeserializer( $this->newSnakDeserializer(), $this->newSnaksDeserializer() );
 	}
 
 	/**

--- a/src/Deserializers/ClaimDeserializer.php
+++ b/src/Deserializers/ClaimDeserializer.php
@@ -40,7 +40,7 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	 * @return bool
 	 */
 	public function isDeserializerFor( $serialization ) {
-		return array_key_exists( 'mainsnak', $serialization );
+		return is_array( $serialization ) && array_key_exists( 'mainsnak', $serialization );
 	}
 
 	/**

--- a/src/Deserializers/ClaimDeserializer.php
+++ b/src/Deserializers/ClaimDeserializer.php
@@ -7,10 +7,7 @@ use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
 use Deserializers\Exceptions\MissingAttributeException;
-use Deserializers\Exceptions\MissingTypeException;
-use Deserializers\Exceptions\UnsupportedTypeException;
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Claim\Statement;
 
 /**
  * @since 0.1
@@ -19,12 +16,6 @@ use Wikibase\DataModel\Claim\Statement;
  * @author Thomas Pellissier Tanon
  */
 class ClaimDeserializer implements DispatchableDeserializer {
-
-	private $rankIds = array(
-		'deprecated' => Statement::RANK_DEPRECATED,
-		'normal' => Statement::RANK_NORMAL,
-		'preferred' => Statement::RANK_PREFERRED
-	);
 
 	/**
 	 * @var Deserializer
@@ -36,15 +27,9 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	 */
 	private $snaksDeserializer;
 
-	/**
-	 * @var Deserializer
-	 */
-	private $referencesDeserializer;
-
-	public function __construct( Deserializer $snakDeserializer, Deserializer $snaksDeserializer, Deserializer $referencesDeserializer ) {
+	public function __construct( Deserializer $snakDeserializer, Deserializer $snaksDeserializer ) {
 		$this->snakDeserializer = $snakDeserializer;
 		$this->snaksDeserializer = $snaksDeserializer;
-		$this->referencesDeserializer = $referencesDeserializer;
 	}
 
 	/**
@@ -55,15 +40,7 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	 * @return bool
 	 */
 	public function isDeserializerFor( $serialization ) {
-		return $this->hasType( $serialization ) && $this->hasCorrectType( $serialization );
-	}
-
-	private function hasType( $serialization ) {
-		return is_array( $serialization ) && array_key_exists( 'type', $serialization );
-	}
-
-	private function hasCorrectType( $serialization ) {
-		return in_array( $serialization['type'], array( 'claim', 'statement' ) );
+		return array_key_exists( 'mainsnak', $serialization );
 	}
 
 	/**
@@ -71,12 +48,13 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	 *
 	 * @param mixed $serialization
 	 *
-	 * @return object
+	 * @return Claim
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {
-		$this->assertCanDeserialize( $serialization );
-		$this->requireAttribute( $serialization, 'mainsnak' );
+		if ( !$this->isDeserializerFor( $serialization ) ) {
+			throw new MissingAttributeException( 'mainsnak' );
+		}
 
 		return $this->getDeserialized( $serialization );
 	}
@@ -84,15 +62,10 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	private function getDeserialized( array $serialization ) {
 		$mainSnak = $this->snakDeserializer->deserialize( $serialization['mainsnak'] );
 
-		$claim = $serialization['type'] === 'statement' ? new Statement( $mainSnak ) : new Claim( $mainSnak );
+		$claim = new Claim( $mainSnak );
 
 		$this->setGuidFromSerialization( $serialization, $claim );
 		$this->setQualifiersFromSerialization( $serialization, $claim );
-
-		if ( $serialization['type'] === 'statement' ) {
-			$this->setRankFromSerialization( $serialization, $claim );
-			$this->setReferencesFromSerialization( $serialization, $claim );
-		}
 
 		return $claim;
 	}
@@ -123,44 +96,6 @@ class ClaimDeserializer implements DispatchableDeserializer {
 		}
 
 		$claim->setQualifiers( $qualifiers );
-	}
-
-	private function setRankFromSerialization( array &$serialization, Statement $statement ) {
-		if ( !array_key_exists( 'rank', $serialization ) ) {
-			return;
-		}
-
-		if ( !array_key_exists( $serialization['rank'], $this->rankIds ) ) {
-			throw new DeserializationException( 'The rank ' . $serialization['rank'] . ' is not a valid rank.' );
-		}
-
-		$statement->setRank( $this->rankIds[$serialization['rank']] );
-	}
-
-	private function setReferencesFromSerialization( array &$serialization, Statement $statement ) {
-		if ( !array_key_exists( 'references', $serialization ) ) {
-			return;
-		}
-
-		$statement->setReferences( $this->referencesDeserializer->deserialize( $serialization['references'] ) );
-	}
-
-	private function assertCanDeserialize( $serialization ) {
-		if ( !$this->hasType( $serialization ) ) {
-			throw new MissingTypeException();
-		}
-
-		if ( !$this->hasCorrectType( $serialization ) ) {
-			throw new UnsupportedTypeException( $serialization['type'] );
-		}
-	}
-
-	protected function requireAttribute( array $array, $attributeName ) {
-		if ( !array_key_exists( $attributeName, $array ) ) {
-			throw new MissingAttributeException(
-				$attributeName
-			);
-		}
 	}
 
 	private function assertQualifiersOrderIsArray( array $serialization ) {

--- a/src/Deserializers/StatementDeserializer.php
+++ b/src/Deserializers/StatementDeserializer.php
@@ -2,6 +2,7 @@
 
 namespace Wikibase\DataModel\Deserializers;
 
+use Deserializers\Deserializer;
 use Deserializers\DispatchableDeserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\MissingAttributeException;
@@ -44,7 +45,7 @@ class StatementDeserializer implements DispatchableDeserializer {
 	 * @return bool
 	 */
 	public function isDeserializerFor( $serialization ) {
-		return array_key_exists( 'claim', $serialization );
+		return is_array( $serialization ) && array_key_exists( 'claim', $serialization );
 	}
 
 	/**
@@ -66,7 +67,9 @@ class StatementDeserializer implements DispatchableDeserializer {
 	private function getDeserialized( array $serialization ) {
 		$claim = $this->claimDeserializer->deserialize( $serialization['claim'] );
 
-		$statement = new Statement( $claim );
+		// @note this is a temporary solution, should be fixed with DataModel 2.0
+		$statement = new Statement( $claim->getMainSnak(), $claim->getQualifiers() );
+		$statement->setGuid( $claim->getGuid() );
 
 		$this->setRankFromSerialization( $serialization, $statement );
 		$this->setReferencesFromSerialization( $serialization, $statement );

--- a/src/Deserializers/StatementDeserializer.php
+++ b/src/Deserializers/StatementDeserializer.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Wikibase\DataModel\Deserializers;
+
+use Deserializers\DispatchableDeserializer;
+use Deserializers\Exceptions\DeserializationException;
+use Deserializers\Exceptions\MissingAttributeException;
+use Wikibase\DataModel\Statement\Statement;
+
+/**
+ * @since 1.2
+ *
+ * @license GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+class StatementDeserializer implements DispatchableDeserializer {
+
+	private $rankIds = array(
+		'deprecated' => Statement::RANK_DEPRECATED,
+		'normal' => Statement::RANK_NORMAL,
+		'preferred' => Statement::RANK_PREFERRED
+	);
+
+	/**
+	 * @var Deserializer
+	 */
+	private $claimDeserializer;
+
+	/**
+	 * @var Deserializer
+	 */
+	private $referencesDeserializer;
+
+	public function __construct( Deserializer $claimDeserializer, Deserializer $referencesDeserializer ) {
+		$this->claimDeserializer = $claimDeserializer;
+		$this->referencesDeserializer = $referencesDeserializer;
+	}
+
+	/**
+	 * @see DispatchableDeserializer::isDeserializerFor
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return bool
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return array_key_exists( 'claim', $serialization );
+	}
+
+	/**
+	 * @see Deserializer::deserialize
+	 *
+	 * @param mixed $serialization
+	 *
+	 * @return Statement
+	 * @throws DeserializationException
+	 */
+	public function deserialize( $serialization ) {
+		if ( !$this->isDeserializerFor( $serialization ) ) {
+			throw new MissingAttributeException( 'claim' );
+		}
+
+		return $this->getDeserialized( $serialization );
+	}
+
+	private function getDeserialized( array $serialization ) {
+		$claim = $this->claimDeserializer->deserialize( $serialization['claim'] );
+
+		$statement = new Statement( $claim );
+
+		$this->setRankFromSerialization( $serialization, $statement );
+		$this->setReferencesFromSerialization( $serialization, $statement );
+
+		return $statement;
+	}
+
+	private function setRankFromSerialization( array &$serialization, Statement $statement ) {
+		if ( !array_key_exists( 'rank', $serialization ) ) {
+			return;
+		}
+
+		if ( !array_key_exists( $serialization['rank'], $this->rankIds ) ) {
+			throw new DeserializationException( 'The rank ' . $serialization['rank'] . ' is not a valid rank.' );
+		}
+
+		$statement->setRank( $this->rankIds[$serialization['rank']] );
+	}
+
+	private function setReferencesFromSerialization( array &$serialization, Statement $statement ) {
+		if ( !array_key_exists( 'references', $serialization ) ) {
+			return;
+		}
+
+		$statement->setReferences( $this->referencesDeserializer->deserialize( $serialization['references'] ) );
+	}
+
+}

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -58,6 +58,15 @@ class SerializerFactory {
 	}
 
 	/**
+	 * Returns a Serializer that can serialize Statement objects.
+	 *
+	 * @return Serializer
+	 */
+	public function newStatementSerializer() {
+		return new Serializers\StatementSerializer( $this->newClaimSerializer(), $this->newReferenceSerializer() );
+	}
+
+	/**
 	 * Returns a Serializer that can serialize Claims objects.
 	 *
 	 * @return Serializer
@@ -72,7 +81,7 @@ class SerializerFactory {
 	 * @return Serializer
 	 */
 	public function newClaimSerializer() {
-		return new ClaimSerializer( $this->newSnakSerializer(), $this->newSnaksSerializer(), $this->newReferencesSerializer() );
+		return new ClaimSerializer( $this->newSnakSerializer(), $this->newSnaksSerializer() );
 	}
 
 	/**

--- a/src/Serializers/StatementSerializer.php
+++ b/src/Serializers/StatementSerializer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Wikibase\DataModel\Serializers;
+
+use Wikibase\DataModel\Statement\Statement;
+use Serializers\DispatchableSerializer;
+use Serializers\Exceptions\SerializationException;
+use Serializers\Exceptions\UnsupportedObjectException;
+use Serializers\Serializer;
+
+/**
+ * @since 1.2
+ *
+ * @license GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+class StatementSerializer implements DispatchableSerializer {
+
+	private $rankLabels = array(
+		Statement::RANK_DEPRECATED => 'deprecated',
+		Statement::RANK_NORMAL => 'normal',
+		Statement::RANK_PREFERRED => 'preferred'
+	);
+
+	/**
+	 * @var Serializer
+	 */
+	private $claimSerializer;
+
+	/**
+	 * @var Serializer
+	 */
+	private $referencesSerializer;
+
+	public function __construct( Serializer $claimSerializer, Serializer $referencesSerializer ) {
+		$this->claimSerializer = $claimSerializer;
+		$this->referencesSerializer = $referencesSerializer;
+	}
+
+	/**
+	 * @see Serializer::isSerializerFor
+	 *
+	 * @param mixed $object
+	 *
+	 * @return bool
+	 */
+	public function isSerializerFor( $object ) {
+		return $object instanceof Statement;
+	}
+
+	/**
+	 * @see Serializer::serialize
+	 *
+	 * @param mixed $object
+	 *
+	 * @return array
+	 * @throws SerializationException
+	 */
+	public function serialize( $object ) {
+		if ( !$this->isSerializerFor( $object ) ) {
+			throw new UnsupportedObjectException(
+				$object,
+				'StatementSerializer can only serialize Statement objects'
+			);
+		}
+
+		return $this->getSerialized( $object );
+	}
+
+	private function getSerialized( Statement $statement ) {
+		$serialization = array(
+			'claim' => $this->claimSerializer->serialize( $statement->getClaim() )
+		);
+
+		$this->addRankToSerialization( $statement, $serialization );
+		$this->addReferencesToSerialization( $statement, $serialization );
+
+		return $serialization;
+	}
+
+	private function addRankToSerialization( Statement $statement, array &$serialization ) {
+		$serialization['rank'] = $this->rankLabels[$statement->getRank()];
+	}
+
+	private function addReferencesToSerialization( Statement $statement, array &$serialization ) {
+		$references = $statement->getReferences();
+
+		if ( $references->count() != 0 ) {
+			$serialization['references'] = $this->referencesSerializer->serialize( $statement->getReferences() );
+		}
+	}
+
+}

--- a/tests/integration/ClaimSerializationRoundtripTest.php
+++ b/tests/integration/ClaimSerializationRoundtripTest.php
@@ -5,7 +5,6 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Claim\Statement;
 use Wikibase\DataModel\DeserializerFactory;
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
 use Wikibase\DataModel\SerializerFactory;
@@ -41,23 +40,11 @@ class ClaimSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 			new Claim( new PropertyNoValueSnak( 42 ) )
 		);
 
-		$claims[] = array(
-			new Statement( new PropertyNoValueSnak( 42 ) )
-		);
-
 		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
 		$claim->setGuid( 'q42' );
 		$claims[] = array( $claim );
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_PREFERRED );
-		$claims[] = array( $claim );
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_DEPRECATED );
-		$claims[] = array( $claim );
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
+		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
 		$claim->setQualifiers( new SnakList( array() ) );
 		$claims[] = array( $claim );
 
@@ -69,7 +56,7 @@ class ClaimSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 		) ) );
 		$claims[] = array( $claim );
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
+		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
 		$claim->setQualifiers( new SnakList( array(
 			new PropertyNoValueSnak( 42 )
 		) ) );

--- a/tests/integration/ReferenceSerializationRoundtripTest.php
+++ b/tests/integration/ReferenceSerializationRoundtripTest.php
@@ -22,7 +22,7 @@ class ReferenceSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider referenceProvider
 	 */
-	public function testSnakSerializationRoundtrips( Reference $reference ) {
+	public function testReferenceSerializationRoundtrips( Reference $reference ) {
 		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
 			new DataValueDeserializer(),

--- a/tests/integration/ReferencesSerializationRoundtripTest.php
+++ b/tests/integration/ReferencesSerializationRoundtripTest.php
@@ -22,7 +22,7 @@ class ReferencesSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider referencesProvider
 	 */
-	public function testReferenceSerializationRoundtrips( References $references ) {
+	public function testReferencesSerializationRoundtrips( References $references ) {
 		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
 			new DataValueDeserializer(),

--- a/tests/integration/SnaksSerializationRoundtripTest.php
+++ b/tests/integration/SnaksSerializationRoundtripTest.php
@@ -22,7 +22,7 @@ class SnaksSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider snaksProvider
 	 */
-	public function testSnakSerializationRoundtrips( Snaks $snak ) {
+	public function testSnaksSerializationRoundtrips( Snaks $snak ) {
 		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
 			new DataValueDeserializer(),

--- a/tests/integration/StatementSerializationRoundtripTet.php
+++ b/tests/integration/StatementSerializationRoundtripTet.php
@@ -22,59 +22,55 @@ class StatementSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider statementsProvider
 	 */
-	public function testStatementSerializationRoundtrips( Claim $claim ) {
+	public function testStatementSerializationRoundtrips( Statement $statement ) {
 		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);
 
-		$serialization = $serializerFactory->newClaimSerializer()->serialize( $claim );
-		$newClaim = $deserializerFactory->newClaimDeserializer()->deserialize( $serialization );
-		$this->assertEquals( $claim->getHash(), $newClaim->getHash() );
+		$serialization = $serializerFactory->newStatementSerializer()->serialize( $statement );
+		$newStatement = $deserializerFactory->newStatementDeserializer()->deserialize( $serialization );
+		$this->assertEquals( $statement->getHash(), $newStatement->getHash() );
 	}
 
 	public function statementsProvider() {
-		$claims = array();
+		$statements = array();
 
-		$claims[] = array(
-			new Claim( new PropertyNoValueSnak( 42 ) )
+		$statements[] = array(
+			new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) )
 		);
 
-		$claims[] = array(
-			new Statement( new PropertyNoValueSnak( 42 ) )
-		);
+		$statement = new Claim( new PropertyNoValueSnak( 42 ) );
+		$statement->setGuid( 'q42' );
+		$statements[] = array( $statement );
 
-		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
-		$claim->setGuid( 'q42' );
-		$claims[] = array( $claim );
+		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement->setRank( Claim::RANK_PREFERRED );
+		$statements[] = array( $statement );
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_PREFERRED );
-		$claims[] = array( $claim );
+		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement->setRank( Claim::RANK_DEPRECATED );
+		$statements[] = array( $statement );
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_DEPRECATED );
-		$claims[] = array( $claim );
+		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement->setQualifiers( new SnakList( array() ) );
+		$statements[] = array( $statement );
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setQualifiers( new SnakList( array() ) );
-		$claims[] = array( $claim );
-
-		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
-		$claim->setQualifiers( new SnakList( array(
+		$statement = new Claim( new PropertyNoValueSnak( 42 ) );
+		$statement->setQualifiers( new SnakList( array(
 			new PropertySomeValueSnak( 42 ),
 			new PropertyNoValueSnak( 42 ),
 			new PropertySomeValueSnak( 24 )
 		) ) );
-		$claims[] = array( $claim );
+		$statements[] = array( $statement );
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setQualifiers( new SnakList( array(
+		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement->setQualifiers( new SnakList( array(
 			new PropertyNoValueSnak( 42 )
 		) ) );
-		$claims[] = array( $claim );
+		$statements[] = array( $statement );
 
-		return $claims;
+		return $statements;
 	}
 }

--- a/tests/integration/StatementSerializationRoundtripTet.php
+++ b/tests/integration/StatementSerializationRoundtripTet.php
@@ -15,14 +15,14 @@ use Wikibase\DataModel\Snak\SnakList;
 
 /**
  * @licence GNU GPL v2+
- * @author Thomas Pellissier Tanon
+ * @author Bene* < benestar.wikimedia@gmail.com >
  */
-class ClaimSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
+class StatementSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @dataProvider claimsProvider
+	 * @dataProvider statementsProvider
 	 */
-	public function testClaimSerializationRoundtrips( Claim $claim ) {
+	public function testStatementSerializationRoundtrips( Claim $claim ) {
 		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
 			new DataValueDeserializer(),
@@ -34,7 +34,7 @@ class ClaimSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals( $claim->getHash(), $newClaim->getHash() );
 	}
 
-	public function claimsProvider() {
+	public function statementsProvider() {
 		$claims = array();
 
 		$claims[] = array(

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -45,6 +45,19 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewStatementDeserializer() {
+		$this->assertTrue( $this->buildDeserializerFactory()->newStatementDeserializer()->isDeserializerFor(
+			array(
+				'claim' => array(
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					)
+				)
+			)
+		) );
+	}
+
 	public function testNewClaimsDeserializer() {
 		$this->assertDeserializesWithoutException(
 			$this->buildDeserializerFactory()->newClaimsDeserializer(),
@@ -61,8 +74,7 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => 'P42'
-				),
-				'type' => 'claim'
+				)
 			)
 		) );
 	}

--- a/tests/unit/Deserializers/ClaimDeserializerTest.php
+++ b/tests/unit/Deserializers/ClaimDeserializerTest.php
@@ -3,9 +3,7 @@
 namespace Tests\Wikibase\DataModel\Deserializers;
 
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Claim\Statement;
 use Wikibase\DataModel\Deserializers\ClaimDeserializer;
-use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\SnakList;
@@ -43,14 +41,7 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 				new PropertyNoValueSnak( 42 )
 			) ) ) );
 
-
-		$referencesDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
-		$referencesDeserializerMock->expects( $this->any() )
-			->method( 'deserialize' )
-			->with( $this->equalTo( array() ) )
-			->will( $this->returnValue( new ReferenceList() ) );
-
-		return new ClaimDeserializer( $snakDeserializerMock, $snaksDeserializerMock, $referencesDeserializerMock );
+		return new ClaimDeserializer( $snakDeserializerMock, $snaksDeserializerMock );
 	}
 
 	public function deserializableProvider() {
@@ -60,8 +51,7 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 					'mainsnak' => array(
 						'snaktype' => 'novalue',
 						'property' => 'P42'
-					),
-					'type' => 'claim'
+					)
 				)
 			),
 			array(
@@ -69,11 +59,9 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 					'mainsnak' => array(
 						'snaktype' => 'novalue',
 						'property' => 'P42'
-					),
-					'type' => 'statement',
-					'rank' => 'normal'
+					)
 				)
-			),
+			)
 		);
 	}
 
@@ -86,12 +74,7 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 				array(
 					'id' => 'P10'
 				)
-			),
-			array(
-				array(
-					'type' => '42'
-				)
-			),
+			)
 		);
 	}
 
@@ -104,19 +87,7 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => 'P42'
-				),
-				'type' => 'claim'
-			)
-		);
-
-		$serializations[] = array(
-			new Statement( new PropertyNoValueSnak( 42 ) ),
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => 'P42'
-				),
-				'type' => 'statement'
+				)
 			)
 		);
 
@@ -129,54 +100,11 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => 'P42'
-				),
-				'type' => 'claim'
+				)
 			)
 		);
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_PREFERRED );
-		$serializations[] = array(
-			$claim,
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'preferred'
-			)
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_NORMAL );
-		$serializations[] = array(
-			$claim,
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
-			)
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_DEPRECATED );
-		$serializations[] = array(
-			$claim,
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'deprecated'
-			)
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
+		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
 		$claim->setQualifiers( new SnakList( array() ) );
 		$serializations[] = array(
 			$claim,
@@ -184,13 +112,11 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
+				)
 			)
 		);
 
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
+		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
 		$claim->setQualifiers( new SnakList( array(
 			new PropertyNoValueSnak( 42 )
 		) ) );
@@ -208,24 +134,7 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 							'property' => 'P42'
 						)
 					)
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
-			)
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setReferences( new ReferenceList() );
-		$serializations[] = array(
-			$claim,
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => "P42"
-				),
-				'references' => array(),
-				'type' => 'statement',
-				'rank' => 'normal'
+				)
 			)
 		);
 
@@ -244,7 +153,16 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 		return array(
 			array(
 				array(
-					'type' => 'claim'
+					'foo' => 'bar'
+				)
+			),
+			array(
+				array(
+					'id' => 42,
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					)
 				)
 			),
 			array(
@@ -254,19 +172,9 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 						'snaktype' => 'novalue',
 						'property' => 'P42'
 					),
-					'type' => 'claim'
+					'qualifiers-order' => 'foo'
 				)
-			),
-			array(
-				array(
-					'mainsnak' => array(
-						'snaktype' => 'novalue',
-						'property' => 'P42'
-					),
-					'type' => 'statement',
-					'rank' => 'nyan-cat'
-				)
-			),
+			)
 		);
 	}
 
@@ -344,8 +252,7 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 			'qualifiers-order' => array(
 				'P42',
 				'P24'
-			),
-			'type' => 'claim'
+			)
 		);
 
 		$this->assertEquals( $claim->getHash(), $claimDeserializer->deserialize( $serialization )->getHash() );

--- a/tests/unit/Deserializers/ClaimsDeserializerTest.php
+++ b/tests/unit/Deserializers/ClaimsDeserializerTest.php
@@ -26,9 +26,7 @@ class ClaimsDeserializerTest extends DeserializerBaseTest {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
+				)
 			) ) )
 			->will( $this->returnValue( $claim ) );
 
@@ -47,9 +45,7 @@ class ClaimsDeserializerTest extends DeserializerBaseTest {
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						)
 					)
 				)
@@ -61,17 +57,13 @@ class ClaimsDeserializerTest extends DeserializerBaseTest {
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						),
 						array(
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						)
 					)
 				)
@@ -116,9 +108,7 @@ class ClaimsDeserializerTest extends DeserializerBaseTest {
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						)
 					)
 				)

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -39,9 +39,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 						'mainsnak' => array(
 							'snaktype' => 'novalue',
 							'property' => 'P42'
-						),
-						'type' => 'statement',
-						'rank' => 'normal'
+						)
 					)
 				)
 			) ) )
@@ -189,9 +187,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						)
 					)
 				)

--- a/tests/unit/Deserializers/StatementDeserializerTest.php
+++ b/tests/unit/Deserializers/StatementDeserializerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Wikibase\DataModel\Deserializers;
+
+use Wikibase\DataModel\Claim\Claim;
+use Wikibase\DataModel\Deserializers\StatementDeserializer;
+use Wikibase\DataModel\Reference;
+use Wikibase\DataModel\ReferenceList;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Snak\SnakList;
+use Wikibase\DataModel\Statement\Statement;
+
+/**
+ * @covers Wikibase\DataModel\Deserializers\StatementDeserializer
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+class StatementDeserializerTest extends DeserializerBaseTest {
+
+	/**
+	 * @var References $references
+	 */
+	static $references = null;
+
+	public function buildDeserializer() {
+		$statementDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
+		$statementDeserializerMock->expects( $this->any() )
+			->method( 'deserialize' )
+			->with( $this->equalTo( array( 'this is' => 'a claim' ) ) )
+			->will( $this->returnValue( new Claim( new PropertyNoValueSnak( 42 ) ) ) );
+
+		$referencesDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
+		$referencesDeserializerMock->expects( $this->any() )
+			->method( 'deserialize' )
+			->with( $this->equalTo( array( 'ref' ) ) )
+			->will( $this->returnValue( self::$references ) );
+
+		return new StatementDeserializer( $statementDeserializerMock, $referencesDeserializerMock );
+	}
+
+	public function deserializableProvider() {
+		return array(
+			array(
+				array(
+					'claim' => array( 'this is' => 'a claim' )
+				)
+			),
+			array(
+				array(
+					'claim' => array( 'this is' => 'a claim' ),
+					'rank' => 'normal'
+				)
+			),
+			array(
+				array(
+					'claim' => array( 'this is' => 'a claim' ),
+					'references' => array( 'ref' ),
+					'rank' => 'normal'
+				)
+			)
+		);
+	}
+
+	public function nonDeserializableProvider() {
+		return array(
+			array(
+				42
+			),
+			array(
+				array(
+					'rank' => 'normal'
+				)
+			)
+		);
+	}
+
+	public function deserializationProvider() {
+		$serializations = array();
+
+		$serializations[] = array(
+			new Statement( new PropertyNoValueSnak( 42 ) ),
+			array(
+				'claim' => array( 'this is' => 'a claim' )
+			)
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setRank( Statement::RANK_PREFERRED );
+		$serializations[] = array(
+			$statement,
+			array(
+				'claim' => array( 'this is' => 'a claim' ),
+				'rank' => 'preferred'
+			)
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setRank( Statement::RANK_NORMAL );
+		$serializations[] = array(
+			$statement,
+			array(
+				'claim' => array( 'this is' => 'a claim' ),
+				'rank' => 'normal'
+			)
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setRank( Statement::RANK_DEPRECATED );
+		$serializations[] = array(
+			$statement,
+			array(
+				'claim' => array( 'this is' => 'a claim' ),
+				'rank' => 'deprecated'
+			)
+		);
+
+		if ( self::$references === null ) {
+			self::$references = new ReferenceList( array( new Reference( new SnakList( new PropertyNoValueSnak( 42 ) ) ) ) );
+		}
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setReferences( self::$references );
+		$serializations[] = array(
+			$statement,
+			array(
+				'claim' => array( 'this is' => 'a claim' ),
+				'references' => array( 'ref' )
+			)
+		);
+
+		return $serializations;
+	}
+
+	/**
+	 * @dataProvider invalidDeserializationProvider
+	 */
+	public function testInvalidSerialization( $serialization ) {
+		$this->setExpectedException( '\Deserializers\Exceptions\DeserializationException' );
+		$this->buildDeserializer()->deserialize( $serialization );
+	}
+
+	public function invalidDeserializationProvider() {
+		return array(
+			array(
+				array(
+					'foo' => 'bar'
+				)
+			),
+			array(
+				array(
+					'claim' => array( 'this is' => 'a claim' ),
+					'rank' => 'nyan-cat'
+				)
+			),
+		);
+	}
+}

--- a/tests/unit/Serializers/ClaimSerializerTest.php
+++ b/tests/unit/Serializers/ClaimSerializerTest.php
@@ -3,10 +3,7 @@
 namespace Tests\Wikibase\DataModel\Serializers;
 
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Claim\Statement;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Reference;
-use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\Serializers\ClaimSerializer;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
@@ -26,7 +23,7 @@ class ClaimSerializerTest extends SerializerBaseTest {
 			->method( 'serialize' )
 			->will( $this->returnValue( array(
 				'snaktype' => 'novalue',
-				'property' => "P42"
+				'property' => 'P42'
 			) ) );
 
 		$snaksSerializerMock = $this->getMock( '\Serializers\Serializer' );
@@ -41,26 +38,13 @@ class ClaimSerializerTest extends SerializerBaseTest {
 				)
 			) ) );
 
-		$referencesSerializerMock = $this->getMock( '\Serializers\Serializer' );
-		$referencesSerializerMock->expects( $this->any() )
-			->method( 'serialize' )
-			->will( $this->returnValue( array(
-				array(
-					'hash' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
-					'snaks' => array()
-				)
-			) ) );
-
-		return new ClaimSerializer( $snakSerializerMock, $snaksSerializerMock, $referencesSerializerMock );
+		return new ClaimSerializer( $snakSerializerMock, $snaksSerializerMock );
 	}
 
 	public function serializableProvider() {
 		return array(
 			array(
 				new Claim( new PropertyNoValueSnak( 42 ) )
-			),
-			array(
-				new Statement( new PropertyNoValueSnak( 42 ) )
 			),
 		);
 	}
@@ -87,22 +71,9 @@ class ClaimSerializerTest extends SerializerBaseTest {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => 'P42'
-				),
-				'type' => 'claim'
+				)
 			),
 			new Claim( new PropertyNoValueSnak( 42 ) )
-		);
-
-		$serializations[] = array(
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
-			),
-			new Statement( new PropertyNoValueSnak( 42 ) )
 		);
 
 		$claim = new Claim( new PropertyNoValueSnak( 42 ) );
@@ -113,99 +84,7 @@ class ClaimSerializerTest extends SerializerBaseTest {
 				'mainsnak' => array(
 					'snaktype' => 'novalue',
 					'property' => "P42"
-				),
-				'type' => 'claim'
-			),
-			$claim
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_PREFERRED );
-		$serializations[] = array(
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => "P42"
-				),
-				'type' => 'statement',
-				'rank' => 'preferred'
-			),
-			$claim
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setRank( Claim::RANK_DEPRECATED );
-		$serializations[] = array(
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => 'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'deprecated'
-			),
-			$claim
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setQualifiers( new SnakList( array() ) );
-		$serializations[] = array(
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => "P42"
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
-			),
-			$claim
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setQualifiers( new SnakList( array(
-			new PropertyNoValueSnak( 42 )
-		) ) );
-		$serializations[] = array(
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => "P42"
-				),
-				'qualifiers' => array(
-					'P42' => array(
-						array(
-							'snaktype' => 'novalue',
-							'property' => 'P42'
-						)
-					)
-				),
-				'qualifiers-order' => array(
-					'P42'
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
-			),
-			$claim
-		);
-
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setReferences( new ReferenceList( array(
-			new Reference()
-		) ) );
-		$serializations[] = array(
-			array(
-				'mainsnak' => array(
-					'snaktype' => 'novalue',
-					'property' => "P42"
-				),
-				'references' => array(
-					array(
-						'hash' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
-						'snaks' => array()
-					)
-				),
-				'type' => 'statement',
-				'rank' => 'normal'
+				)
 			),
 			$claim
 		);
@@ -246,10 +125,10 @@ class ClaimSerializerTest extends SerializerBaseTest {
 				'qualifiers-order' => array(
 					'P42',
 					'P24'
-				),
-				'type' => 'claim'
+				)
 			),
 			$claimSerializer->serialize( $claim )
 		);
 	}
+
 }

--- a/tests/unit/Serializers/EntitySerializerTest.php
+++ b/tests/unit/Serializers/EntitySerializerTest.php
@@ -31,9 +31,7 @@ class EntitySerializerTest extends SerializerBaseTest {
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						)
 					)
 				);
@@ -192,9 +190,7 @@ class EntitySerializerTest extends SerializerBaseTest {
 							'mainsnak' => array(
 								'snaktype' => 'novalue',
 								'property' => 'P42'
-							),
-							'type' => 'statement',
-							'rank' => 'normal'
+							)
 						)
 					)
 				),

--- a/tests/unit/Serializers/StatementSerializerTest.php
+++ b/tests/unit/Serializers/StatementSerializerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Wikibase\DataModel\Serializers;
+
+use Wikibase\DataModel\Claim\Claim;
+use Wikibase\DataModel\Claim\Statement;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Reference;
+use Wikibase\DataModel\ReferenceList;
+use Wikibase\DataModel\Serializers\StatementSerializer;
+use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Snak\SnakList;
+
+/**
+ * @covers Wikibase\DataModel\Serializers\StatementSerializer
+ *
+ * @licence GNU GPL v2+
+ * @author Bene* < benestar.wikimedia@gmail.com >
+ */
+class StatementSerializerTest extends SerializerBaseTest {
+
+	protected function buildSerializer() {
+		$statementSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$statementSerializerMock->expects( $this->any() )
+			->method( 'serialize' )
+			->will( $this->returnValue( array( 
+				'mainsnak' => array(
+					'snaktype' => 'novalue',
+					'property' => 'P42'
+				)
+			) ) );
+
+		$referencesSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$referencesSerializerMock->expects( $this->any() )
+			->method( 'serialize' )
+			->will( $this->returnValue( array(
+				array(
+					'hash' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+					'snaks' => array()
+				)
+			) ) );
+
+		return new StatementSerializer( $statementSerializerMock, $referencesSerializerMock );
+	}
+
+	public function serializableProvider() {
+		return array(
+			array(
+				new Statement( new PropertyNoValueSnak( 42 ) )
+			),
+		);
+	}
+
+	public function nonSerializableProvider() {
+		return array(
+			array(
+				5
+			),
+			array(
+				array()
+			),
+			array(
+				new ItemId( 'Q42' )
+			),
+		);
+	}
+
+	public function serializationProvider() {
+		$serializations = array();
+
+		$serializations[] = array(
+			array(
+				'claim' => array(
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					),
+				),
+				'rank' => 'normal'
+			),
+			new Statement( new PropertyNoValueSnak( 42 ) )
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setRank( Claim::RANK_PREFERRED );
+		$serializations[] = array(
+			array(
+				'claim' => array(
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					),
+				),
+				'rank' => 'preferred'
+			),
+			$statement
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setRank( Claim::RANK_DEPRECATED );
+		$serializations[] = array(
+			array(
+				'claim' => array(
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					),
+				),
+				'rank' => 'deprecated'
+			),
+			$statement
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setQualifiers( new SnakList( array() ) );
+		$serializations[] = array(
+			array(
+				'claim' => array(
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					),
+				),
+				'rank' => 'normal'
+			),
+			$statement
+		);
+
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setReferences( new ReferenceList( array(
+			new Reference()
+		) ) );
+		$serializations[] = array(
+			array(
+				'claim' => array(
+					'mainsnak' => array(
+						'snaktype' => 'novalue',
+						'property' => 'P42'
+					),
+				),
+				'references' => array(
+					array(
+						'hash' => 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+						'snaks' => array()
+					)
+				),
+				'rank' => 'normal'
+			),
+			$statement
+		);
+
+		return $serializations;
+	}
+
+}


### PR DESCRIPTION
This patch adopts the changes in Statement which uses composition instead of inheritance for claims. It depends on some future version of WikibaseDataModel which supports claims as parameters for the Statement constructor.

See also http://git.io/wXZTag