### PR TITLE
Favor constructors over newEmpty

### DIFF
--- a/src/Deserializers/ItemDeserializer.php
+++ b/src/Deserializers/ItemDeserializer.php
@@ -35,7 +35,7 @@ class ItemDeserializer extends EntityDeserializer {
 	}
 
 	protected function getPartiallyDeserialized( array $serialization ) {
-		$item = Item::newEmpty();
+		$item = new Item();
 
 		$this->setSiteLinksFromSerialization( $item->getSiteLinkList(), $serialization );
 

--- a/tests/integration/EntitySerializationRoundtripTest.php
+++ b/tests/integration/EntitySerializationRoundtripTest.php
@@ -38,34 +38,33 @@ class EntitySerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	public function entityProvider() {
 		$entities = array();
 
-		$entity = Item::newEmpty();
-		$entity->setId( new ItemId( 'Q42' ) );
+		$entity = new Item( new ItemId( 'Q42' ) );
 		$entities[] = array( $entity );
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setLabels( array(
 			'en' => 'Nyan Cat',
 			'fr' => 'Nyan Cat'
 		) );
 		$entities[] = array( $entity );
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setDescriptions( array(
 			'en' => 'A Nyan Cat',
 			'fr' => 'A Nyan Cat'
 		) );
 		$entities[] = array( $entity );
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setAliases( 'en', array( 'Cat', 'My cat' ) );
 		$entity->setAliases( 'fr', array( 'Cat' ) );
 		$entities[] = array( $entity );
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'guid' );
 		$entities[] = array( $entity );
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
 		$entities[] = array( $item );
 
@@ -73,4 +72,5 @@ class EntitySerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 
 		return $entities;
 	}
+
 }

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -54,7 +54,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 		);
 		$entityDeserializerMock->expects( $this->any() )
 			->method( 'getPartiallyDeserialized' )
-			->will( $this->returnValue( Item::newEmpty() ) );
+			->will( $this->returnValue( new Item() ) );
 
 		return $entityDeserializerMock;
 	}
@@ -88,15 +88,14 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 	public function deserializationProvider() {
 		$provider = array(
 			array(
-				Item::newEmpty(),
+				new Item(),
 				array(
 					'type' => 'item'
 				)
 			),
 		);
 
-		$entity = Item::newEmpty();
-		$entity->setId( new ItemId( 'Q42' ) );
+		$entity = new Item( new ItemId( 'Q42' ) );
 		$provider[] = array(
 			$entity,
 			array(
@@ -105,8 +104,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setLabels( array(
 			'en' => 'Nyan Cat',
 			'fr' => 'Nyan Cat'
@@ -128,7 +126,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setDescriptions( array(
 			'en' => 'A Nyan Cat',
 			'fr' => 'A Nyan Cat'
@@ -150,7 +148,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setAliases( 'en', array( 'Cat', 'My cat' ) );
 		$entity->setAliases( 'fr', array( 'Cat' ) );
 		$provider[] = array(
@@ -178,7 +176,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			$entity,

--- a/tests/unit/Deserializers/ItemDeserializerTest.php
+++ b/tests/unit/Deserializers/ItemDeserializerTest.php
@@ -61,14 +61,14 @@ class ItemDeserializerTest extends DeserializerBaseTest {
 	public function deserializationProvider() {
 		$provider = array(
 			array(
-				Item::newEmpty(),
+				new Item(),
 				array(
 					'type' => 'item'
 				)
 			),
 		);
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
 		$provider[] = array(
 			$item,
@@ -86,4 +86,5 @@ class ItemDeserializerTest extends DeserializerBaseTest {
 
 		return $provider;
 	}
+
 }

--- a/tests/unit/Deserializers/PropertyDeserializerTest.php
+++ b/tests/unit/Deserializers/PropertyDeserializerTest.php
@@ -71,8 +71,7 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 	}
 
 	public function deserializationProvider() {
-		$property = Property::newEmpty();
-		$property->setDataTypeId( 'string' );
+		$property = Property::newFromType( 'string' );
 
 		$provider = array(
 			array(
@@ -84,7 +83,7 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			),
 		);
 
-		$property = Property::newEmpty();
+		$property = Property::newFromType( '' );
 		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			$property,
@@ -108,4 +107,5 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 
 		return $provider;
 	}
+
 }

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -34,7 +34,7 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 	public function testNewEntitySerializer() {
 		$this->assertSerializesWithoutException(
 			$this->buildSerializerFactory()->newEntitySerializer(),
-			Item::newEmpty()
+			new Item()
 		);
 
 		$this->assertSerializesWithoutException(

--- a/tests/unit/Serializers/FingerprintSerializerTest.php
+++ b/tests/unit/Serializers/FingerprintSerializerTest.php
@@ -8,7 +8,6 @@ use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Serializers\FingerprintSerializer;
 use Wikibase\DataModel\Serializers\ItemSerializer;
-use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Term\AliasGroupFallback;
 use Wikibase\DataModel\Term\TermFallback;
@@ -41,7 +40,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 	public function serializableProvider() {
 		return array(
 			array(
-				Item::newEmpty()
+				new Item()
 			),
 		);
 	}
@@ -72,11 +71,10 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 				'claims' => array(),
 				'sitelinks' => array(),
 			),
-			Item::newEmpty()
+			new Item()
 		);
 
-		$entity = Item::newEmpty();
-		$entity->setId( new ItemId( 'Q42' ) );
+		$entity = new Item( new ItemId( 'Q42' ) );
 		$argumentLists['id on item'] = array(
 			array(
 				'type' => 'item',
@@ -90,7 +88,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setLabels( array(
 			'en' => 'Nyan Cat',
 			'fr' => 'Nyan Cat'
@@ -116,7 +114,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getFingerprint()->getLabels()->setTerm(
 			new TermFallback( 'de-formal', 'Nyan Cat', 'de', null )
 		);
@@ -138,7 +136,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getFingerprint()->getLabels()->setTerm(
 			new TermFallback( 'zh-cn', 'Nyan Cat', 'zh-cn', 'zh-tw' )
 		);
@@ -160,7 +158,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setDescriptions( array(
 			'en' => 'A Nyan Cat',
 			'fr' => 'A Nyan Cat'
@@ -186,7 +184,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getFingerprint()->getDescriptions()->setTerm(
 			new TermFallback( 'de-formal', 'A Nyan Cat', 'de', null )
 		);
@@ -208,7 +206,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getFingerprint()->getDescriptions()->setTerm(
 			new TermFallback( 'zh-cn', 'A Nyan Cat', 'zh-cn', 'zh-tw' )
 		);
@@ -230,7 +228,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setAliases( 'en', array( 'Cat', 'My cat' ) );
 		$entity->setAliases( 'fr', array( 'Cat' ) );
 		$argumentLists['aliases on item'] = array(
@@ -262,7 +260,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getFingerprint()->getAliasGroups()->setGroup(
 			new AliasGroupFallback( 'de-formal', array( 'Cat' ), 'de', null )
 		);
@@ -286,7 +284,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getFingerprint()->getAliasGroups()->setGroup(
 			new AliasGroupFallback( 'zh-cn', array( 'Cat' ), 'zh-cn', 'zh-tw' )
 		);
@@ -316,7 +314,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 	public function testDescriptionWithOptionObjectsForMaps() {
 		$entitySerializer = new FingerprintSerializer( true );
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setDescriptions( array(
 			'en' => 'A Nyan Cat',
 		) );
@@ -336,7 +334,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 	public function testAliasesWithOptionObjectsForMaps() {
 		$entitySerializer = new FingerprintSerializer( true );
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->setAliases( 'fr', array( 'Cat' ) );
 
 		$result = array();

--- a/tests/unit/Serializers/ItemSerializerTest.php
+++ b/tests/unit/Serializers/ItemSerializerTest.php
@@ -61,7 +61,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 	public function serializableProvider() {
 		return array(
 			array(
-				Item::newEmpty()
+				new Item()
 			),
 		);
 	}
@@ -75,7 +75,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 				array()
 			),
 			array(
-				Property::newEmpty()
+				Property::newFromType( '' )
 			),
 		);
 	}
@@ -91,11 +91,11 @@ class ItemSerializerTest extends SerializerBaseTest {
 					'sitelinks' => array(),
 					'claims' => array(),
 				),
-				Item::newEmpty()
+				new Item()
 			),
 		);
 
-		$entity = Item::newEmpty();
+		$entity = new Item();
 		$entity->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			array(
@@ -120,7 +120,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 			$entity
 		);
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
 		$provider[] = array(
 			array(
@@ -164,7 +164,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 
 		$serializer = new ItemSerializer( $fingerprintSerializer, $claimsSerializerMock, $siteLinkSerializerMock, true );
 
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
 
 		$sitelinks = new stdClass();

--- a/tests/unit/Serializers/PropertySerializerTest.php
+++ b/tests/unit/Serializers/PropertySerializerTest.php
@@ -62,14 +62,13 @@ class PropertySerializerTest extends SerializerBaseTest {
 				array()
 			),
 			array(
-				Item::newEmpty()
+				new Item()
 			),
 		);
 	}
 
 	public function serializationProvider() {
-		$property = Property::newEmpty();
-		$property->setDataTypeId( 'string' );
+		$property = Property::newFromType( 'string' );
 
 		$provider = array(
 			array(
@@ -85,7 +84,7 @@ class PropertySerializerTest extends SerializerBaseTest {
 			),
 		);
 
-		$property = Property::newEmpty();
+		$property = Property::newFromType( '' );
 		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			array(


### PR DESCRIPTION
1. Favor constructor calls over static methods.
2. Favor using constructor parameters over calling `setId` (see https://github.com/wmde/WikibaseDataModel/pull/348).