### PR TITLE
Use StatementListSerializer where appropriate

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -15,6 +15,7 @@ use Wikibase\DataModel\Deserializers\ReferenceListDeserializer;
 use Wikibase\DataModel\Deserializers\SiteLinkDeserializer;
 use Wikibase\DataModel\Deserializers\SnakDeserializer;
 use Wikibase\DataModel\Deserializers\SnakListDeserializer;
+use Wikibase\DataModel\Deserializers\StatementListDeserializer;
 use Wikibase\DataModel\Entity\EntityIdParser;
 
 /**
@@ -53,8 +54,8 @@ class DeserializerFactory {
 	 */
 	public function newEntityDeserializer() {
 		return new DispatchingDeserializer( array(
-			new ItemDeserializer( $this->newEntityIdDeserializer(), $this->newClaimsDeserializer(), $this->newSiteLinkDeserializer() ),
-			new PropertyDeserializer( $this->newEntityIdDeserializer(), $this->newClaimsDeserializer() )
+			new ItemDeserializer( $this->newEntityIdDeserializer(), $this->newStatementListDeserializer(), $this->newSiteLinkDeserializer() ),
+			new PropertyDeserializer( $this->newEntityIdDeserializer(), $this->newStatementListDeserializer() )
 		) );
 	}
 
@@ -74,6 +75,15 @@ class DeserializerFactory {
 	 */
 	public function newClaimsDeserializer() {
 		return new ClaimsDeserializer( $this->newClaimDeserializer() );
+	}
+
+	/**
+	 * Returns a Deserializer that can deserialize StatementList objects.
+	 *
+	 * @return Deserializer
+	 */
+	public function newStatementListDeserializer() {
+		return new StatementListDeserializer( $this->newClaimDeserializer() );
 	}
 
 	/**

--- a/src/Deserializers/EntityDeserializer.php
+++ b/src/Deserializers/EntityDeserializer.php
@@ -7,7 +7,6 @@ use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
 use Deserializers\TypedObjectDeserializer;
 use Wikibase\DataModel\Entity\Entity;
-use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * Package private
@@ -25,18 +24,18 @@ abstract class EntityDeserializer extends TypedObjectDeserializer {
 	/**
 	 * @var Deserializer
 	 */
-	private $claimsDeserializer;
+	private $statementListDeserializer;
 
 	/**
 	 * @param string $entityType
 	 * @param Deserializer $entityIdDeserializer
-	 * @param Deserializer $claimsDeserializer
+	 * @param Deserializer $statementListDeserializer
 	 */
-	public function __construct( $entityType, Deserializer $entityIdDeserializer, Deserializer $claimsDeserializer ) {
+	public function __construct( $entityType, Deserializer $entityIdDeserializer, Deserializer $statementListDeserializer ) {
 		parent::__construct( $entityType, 'type' );
 
 		$this->entityIdDeserializer = $entityIdDeserializer;
-		$this->claimsDeserializer = $claimsDeserializer;
+		$this->statementListDeserializer = $statementListDeserializer;
 	}
 
 	/**
@@ -66,7 +65,7 @@ abstract class EntityDeserializer extends TypedObjectDeserializer {
 		$this->setLabelsFromSerialization( $serialization, $entity );
 		$this->setDescriptionsFromSerialization( $serialization, $entity );
 		$this->setAliasesFromSerialization( $serialization, $entity );
-		$this->setClaimsFromSerialization( $serialization, $entity );
+		$this->setStatementListFromSerialization( $serialization, $entity );
 
 		return $entity;
 	}
@@ -156,13 +155,12 @@ abstract class EntityDeserializer extends TypedObjectDeserializer {
 		$this->assertRequestedAndActualLanguageMatch( $serialization, $requestedLanguage );
 	}
 
-	private function setClaimsFromSerialization( array $serialization, Entity $entity ) {
+	private function setStatementListFromSerialization( array $serialization, Entity $entity ) {
 		if ( !array_key_exists( 'claims', $serialization ) || !method_exists( $entity, 'setStatements' ) ) {
 			return;
 		}
 
-		$claims = $this->claimsDeserializer->deserialize( $serialization['claims'] );
-		$statements = new StatementList( iterator_to_array( $claims ) );
+		$statements = $this->statementListDeserializer->deserialize( $serialization['claims'] );
 		$entity->setStatements( $statements );
 	}
 

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -15,6 +15,7 @@ use Wikibase\DataModel\Serializers\ReferenceSerializer;
 use Wikibase\DataModel\Serializers\SiteLinkSerializer;
 use Wikibase\DataModel\Serializers\SnakSerializer;
 use Wikibase\DataModel\Serializers\SnaksSerializer;
+use Wikibase\DataModel\Serializers\StatementListSerializer;
 use Wikibase\DataModel\Serializers\TypedSnakSerializer;
 
 /**
@@ -70,8 +71,8 @@ class SerializerFactory {
 	public function newEntitySerializer() {
 		$fingerprintSerializer = new FingerprintSerializer( $this->shouldUseObjectsForMaps() );
 		return new DispatchingSerializer( array(
-			new ItemSerializer( $fingerprintSerializer, $this->newClaimsSerializer(), $this->newSiteLinkSerializer(), $this->shouldUseObjectsForMaps() ),
-			new PropertySerializer( $fingerprintSerializer, $this->newClaimsSerializer() ),
+			new ItemSerializer( $fingerprintSerializer, $this->newStatementListSerializer(), $this->newSiteLinkSerializer(), $this->shouldUseObjectsForMaps() ),
+			new PropertySerializer( $fingerprintSerializer, $this->newStatementListSerializer() ),
 		) );
 	}
 
@@ -91,6 +92,15 @@ class SerializerFactory {
 	 */
 	public function newClaimsSerializer() {
 		return new ClaimsSerializer( $this->newClaimSerializer(), $this->shouldUseObjectsForMaps() );
+	}
+
+	/**
+	 * Returns a Serializer that can serialize StatementList objects.
+	 *
+	 * @return Serializer
+	 */
+	public function newStatementListSerializer() {
+		return new StatementListSerializer( $this->newClaimSerializer(), $this->shouldUseObjectsForMaps() );
 	}
 
 	/**

--- a/src/Serializers/ItemSerializer.php
+++ b/src/Serializers/ItemSerializer.php
@@ -6,7 +6,6 @@ use Serializers\DispatchableSerializer;
 use Serializers\Exceptions\SerializationException;
 use Serializers\Exceptions\UnsupportedObjectException;
 use Serializers\Serializer;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Item;
 
 /**
@@ -26,7 +25,7 @@ class ItemSerializer implements DispatchableSerializer {
 	/**
 	 * @var Serializer
 	 */
-	private $claimsSerializer;
+	private $statementListSerializer;
 
 	/**
 	 * @var Serializer
@@ -40,13 +39,18 @@ class ItemSerializer implements DispatchableSerializer {
 
 	/**
 	 * @param FingerprintSerializer $fingerprintSerializer
-	 * @param Serializer $claimsSerializer
+	 * @param Serializer $statementListSerializer
 	 * @param Serializer $siteLinkSerializer
 	 * @param bool $useObjectsForMaps
 	 */
-	public function __construct( FingerprintSerializer $fingerprintSerializer, Serializer $claimsSerializer, Serializer $siteLinkSerializer, $useObjectsForMaps ) {
+	public function __construct(
+		FingerprintSerializer $fingerprintSerializer,
+		Serializer $statementListSerializer,
+		Serializer $siteLinkSerializer,
+		$useObjectsForMaps
+	) {
 		$this->fingerprintSerializer = $fingerprintSerializer;
-		$this->claimsSerializer = $claimsSerializer;
+		$this->statementListSerializer = $statementListSerializer;
 		$this->siteLinkSerializer = $siteLinkSerializer;
 		$this->useObjectsForMaps = $useObjectsForMaps;
 	}
@@ -87,16 +91,14 @@ class ItemSerializer implements DispatchableSerializer {
 		);
 
 		$this->fingerprintSerializer->addBasicsToSerialization( $item, $serialization );
-		$this->addClaimsToSerialization( $item, $serialization );
+		$this->addStatementListToSerialization( $item, $serialization );
 		$this->addSiteLinksToSerialization( $item, $serialization );
 
 		return $serialization;
 	}
 
-	private function addClaimsToSerialization( Item $item, array &$serialization ) {
-		$claims = new Claims( $item->getClaims() );
-
-		$serialization['claims'] = $this->claimsSerializer->serialize( $claims );
+	private function addStatementListToSerialization( Item $item, array &$serialization ) {
+		$serialization['claims'] = $this->statementListSerializer->serialize( $item->getStatements() );
 	}
 
 	private function addSiteLinksToSerialization( Item $item, array &$serialization ) {

--- a/src/Serializers/PropertySerializer.php
+++ b/src/Serializers/PropertySerializer.php
@@ -6,7 +6,6 @@ use Serializers\DispatchableSerializer;
 use Serializers\Exceptions\SerializationException;
 use Serializers\Exceptions\UnsupportedObjectException;
 use Serializers\Serializer;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Property;
 
 /**
@@ -26,15 +25,15 @@ class PropertySerializer implements DispatchableSerializer {
 	/**
 	 * @var Serializer
 	 */
-	private $claimsSerializer;
+	private $statementListSerializer;
 
 	/**
 	 * @param FingerprintSerializer $fingerprintSerializer
-	 * @param Serializer $claimsSerializer
+	 * @param Serializer $statementListSerializer
 	 */
-	public function __construct( FingerprintSerializer $fingerprintSerializer, Serializer $claimsSerializer ) {
+	public function __construct( FingerprintSerializer $fingerprintSerializer, Serializer $statementListSerializer ) {
 		$this->fingerprintSerializer = $fingerprintSerializer;
-		$this->claimsSerializer = $claimsSerializer;
+		$this->statementListSerializer = $statementListSerializer;
 	}
 
 	/**
@@ -74,15 +73,13 @@ class PropertySerializer implements DispatchableSerializer {
 		);
 
 		$this->fingerprintSerializer->addBasicsToSerialization( $entity, $serialization );
-		$this->addClaimsToSerialization( $entity, $serialization );
+		$this->addStatementListToSerialization( $entity, $serialization );
 
 		return $serialization;
 	}
 
-	private function addClaimsToSerialization( Property $entity, array &$serialization ) {
-		$claims = new Claims( $entity->getStatements() );
-
-		$serialization['claims'] = $this->claimsSerializer->serialize( $claims );
+	private function addStatementListToSerialization( Property $entity, array &$serialization ) {
+		$serialization['claims'] = $this->statementListSerializer->serialize( $entity->getStatements() );
 	}
 
 }

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -55,6 +55,16 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testStatementListDeserializer() {
+		$this->assertDeserializesWithoutException(
+			$this->buildDeserializerFactory()->newStatementListDeserializer(),
+			array(
+				'P42' => array(
+				)
+			)
+		);
+	}
+
 	public function testNewClaimDeserializer() {
 		$this->assertTrue( $this->buildDeserializerFactory()->newClaimDeserializer()->isDeserializerFor(
 			array(

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -4,11 +4,11 @@ namespace Tests\Wikibase\DataModel\Deserializers;
 
 use Deserializers\Deserializer;
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * @covers Wikibase\DataModel\Deserializers\EntityDeserializer
@@ -28,11 +28,11 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 			->with( $this->equalTo( 'Q42' ) )
 			->will( $this->returnValue( new ItemId( 'Q42' ) ) );
 
-		$claim = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
-		$claim->setGuid( 'test' );
+		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement->setGuid( 'test' );
 
-		$claimsDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
-		$claimsDeserializerMock->expects( $this->any() )
+		$statementListDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
+		$statementListDeserializerMock->expects( $this->any() )
 			->method( 'deserialize' )
 			->with( $this->equalTo( array(
 				'P42' => array(
@@ -46,11 +46,11 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 					)
 				)
 			) ) )
-			->will( $this->returnValue( new Claims( array( $claim ) ) ) );
+			->will( $this->returnValue( new StatementList( array( $statement ) ) ) );
 
 		$entityDeserializerMock = $this->getMockForAbstractClass(
 			'\Wikibase\DataModel\Deserializers\EntityDeserializer',
-			array( 'item', $entityIdDeserializerMock, $claimsDeserializerMock )
+			array( 'item', $entityIdDeserializerMock, $statementListDeserializerMock )
 		);
 		$entityDeserializerMock->expects( $this->any() )
 			->method( 'getPartiallyDeserialized' )

--- a/tests/unit/Deserializers/ItemDeserializerTest.php
+++ b/tests/unit/Deserializers/ItemDeserializerTest.php
@@ -16,7 +16,7 @@ class ItemDeserializerTest extends DeserializerBaseTest {
 
 	public function buildDeserializer() {
 		$entityIdDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
-		$claimsDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
+		$statementListDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
 
 		$siteLinkDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
 
@@ -29,7 +29,7 @@ class ItemDeserializerTest extends DeserializerBaseTest {
 			) ) )
 			->will( $this->returnValue( new SiteLink( 'enwiki', 'Nyan Cat' ) ) );
 
-		return new ItemDeserializer( $entityIdDeserializerMock, $claimsDeserializerMock, $siteLinkDeserializerMock );
+		return new ItemDeserializer( $entityIdDeserializerMock, $statementListDeserializerMock, $siteLinkDeserializerMock );
 	}
 
 	public function deserializableProvider() {

--- a/tests/unit/Deserializers/PropertyDeserializerTest.php
+++ b/tests/unit/Deserializers/PropertyDeserializerTest.php
@@ -3,11 +3,11 @@
 namespace Tests\Wikibase\DataModel\Deserializers;
 
 use Wikibase\DataModel\Claim\Claim;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Deserializers\PropertyDeserializer;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * @covers Wikibase\DataModel\Deserializers\PropertyDeserializer
@@ -20,11 +20,11 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 	public function buildDeserializer() {
 		$entityIdDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
 
-		$claim = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
-		$claim->setGuid( 'test' );
+		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
+		$statement->setGuid( 'test' );
 
-		$claimsDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
-		$claimsDeserializerMock->expects( $this->any() )
+		$statementListDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
+		$statementListDeserializerMock->expects( $this->any() )
 			->method( 'deserialize' )
 			->with( $this->equalTo( array(
 				'P42' => array(
@@ -38,10 +38,10 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 					)
 				)
 			) ) )
-			->will( $this->returnValue( new Claims( array( $claim ) ) ) );
+			->will( $this->returnValue( new StatementList( array( $statement ) ) ) );
 
 
-		return new PropertyDeserializer( $entityIdDeserializerMock, $claimsDeserializerMock );
+		return new PropertyDeserializer( $entityIdDeserializerMock, $statementListDeserializerMock );
 	}
 
 	public function deserializableProvider() {

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -15,6 +15,7 @@ use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\SnakList;
 use Wikibase\DataModel\Snak\TypedSnak;
+use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * @licence GNU GPL v2+
@@ -54,6 +55,13 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSerializesWithoutException(
 			$this->buildSerializerFactory()->newClaimsSerializer(),
 			new Claims()
+		);
+	}
+
+	public function testNewStatementListSerializer() {
+		$this->assertSerializesWithoutException(
+			$this->buildSerializerFactory()->newStatementListSerializer(),
+			new StatementList()
 		);
 	}
 

--- a/tests/unit/Serializers/FingerprintSerializerTest.php
+++ b/tests/unit/Serializers/FingerprintSerializerTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Wikibase\DataModel\Serializers;
 
 use stdClass;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Serializers\FingerprintSerializer;
 use Wikibase\DataModel\Serializers\ItemSerializer;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Term\AliasGroupFallback;
 use Wikibase\DataModel\Term\TermFallback;
 
@@ -22,10 +22,10 @@ use Wikibase\DataModel\Term\TermFallback;
 class FingerprintSerializerTest extends SerializerBaseTest {
 
 	protected function buildSerializer() {
-		$claimsSerializerMock = $this->getMock( '\Serializers\Serializer' );
-		$claimsSerializerMock->expects( $this->any() )
+		$statementListSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$statementListSerializerMock->expects( $this->any() )
 			->method( 'serialize' )
-			->with( $this->equalTo( new Claims() ) )
+			->with( $this->equalTo( new StatementList() ) )
 			->will( $this->returnValue( array() ) );
 
 		$siteLinkSerializerMock = $this->getMock( '\Serializers\Serializer' );
@@ -34,7 +34,7 @@ class FingerprintSerializerTest extends SerializerBaseTest {
 
 		$entitySerializer = new FingerprintSerializer( false );
 
-		return new ItemSerializer( $entitySerializer, $claimsSerializerMock, $siteLinkSerializerMock, false );
+		return new ItemSerializer( $entitySerializer, $statementListSerializerMock, $siteLinkSerializerMock, false );
 	}
 
 	public function serializableProvider() {

--- a/tests/unit/Serializers/ItemSerializerTest.php
+++ b/tests/unit/Serializers/ItemSerializerTest.php
@@ -3,13 +3,13 @@
 namespace Tests\Wikibase\DataModel\Serializers;
 
 use stdClass;
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Serializers\FingerprintSerializer;
 use Wikibase\DataModel\Serializers\ItemSerializer;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * @covers Wikibase\DataModel\Serializers\ItemSerializer
@@ -21,11 +21,11 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 class ItemSerializerTest extends SerializerBaseTest {
 
 	protected function buildSerializer() {
-		$claimsSerializerMock = $this->getMock( '\Serializers\Serializer' );
-		$claimsSerializerMock->expects( $this->any() )
+		$statementListSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$statementListSerializerMock->expects( $this->any() )
 			->method( 'serialize' )
-			->will( $this->returnCallback( function( Claims $claims ) {
-				if ( $claims->isEmpty() ) {
+			->will( $this->returnCallback( function( StatementList $statementList ) {
+				if ( $statementList->isEmpty() ) {
 					return array();
 				}
 
@@ -55,7 +55,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 
 		$fingerprintSerializer = new FingerprintSerializer( false );
 
-		return new ItemSerializer( $fingerprintSerializer, $claimsSerializerMock, $siteLinkSerializerMock, false );
+		return new ItemSerializer( $fingerprintSerializer, $statementListSerializerMock, $siteLinkSerializerMock, false );
 	}
 
 	public function serializableProvider() {
@@ -144,10 +144,10 @@ class ItemSerializerTest extends SerializerBaseTest {
 	}
 
 	public function testItemSerializerWithOptionObjectsForMaps() {
-		$claimsSerializerMock = $this->getMock( '\Serializers\Serializer' );
-		$claimsSerializerMock->expects( $this->any() )
+		$statementListSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$statementListSerializerMock->expects( $this->any() )
 			->method( 'serialize' )
-			->with( $this->equalTo( new Claims() ) )
+			->with( $this->equalTo( new StatementList() ) )
 			->will( $this->returnValue( array() ) );
 
 		$siteLinkSerializerMock = $this->getMock( '\Serializers\Serializer' );
@@ -162,7 +162,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 
 		$fingerprintSerializer = new FingerprintSerializer( false );
 
-		$serializer = new ItemSerializer( $fingerprintSerializer, $claimsSerializerMock, $siteLinkSerializerMock, true );
+		$serializer = new ItemSerializer( $fingerprintSerializer, $statementListSerializerMock, $siteLinkSerializerMock, true );
 
 		$item = new Item();
 		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );

--- a/tests/unit/Serializers/PropertySerializerTest.php
+++ b/tests/unit/Serializers/PropertySerializerTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Wikibase\DataModel\Serializers;
 
-use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Serializers\FingerprintSerializer;
 use Wikibase\DataModel\Serializers\PropertySerializer;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
+use Wikibase\DataModel\Statement\StatementList;
 
 /**
  * @covers Wikibase\DataModel\Serializers\PropertySerializer
@@ -18,11 +18,11 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 class PropertySerializerTest extends SerializerBaseTest {
 
 	protected function buildSerializer() {
-		$claimsSerializerMock = $this->getMock( 'Serializers\Serializer' );
-		$claimsSerializerMock->expects( $this->any() )
+		$statementListSerializerMock = $this->getMock( 'Serializers\Serializer' );
+		$statementListSerializerMock->expects( $this->any() )
 			->method( 'serialize' )
-			->will( $this->returnCallback( function( Claims $claims ) {
-				if ( $claims->isEmpty() ) {
+			->will( $this->returnCallback( function( StatementList $statementList ) {
+				if ( $statementList->isEmpty() ) {
 					return array();
 				}
 
@@ -42,7 +42,7 @@ class PropertySerializerTest extends SerializerBaseTest {
 
 		$fingerprintSerializer = new FingerprintSerializer( false );
 
-		return new PropertySerializer( $fingerprintSerializer, $claimsSerializerMock );
+		return new PropertySerializer( $fingerprintSerializer, $statementListSerializerMock );
 	}
 
 	public function serializableProvider() {


### PR DESCRIPTION
This replaces the `claims` key with a `statements` key in the serialization which is a breaking change. We might consider to use `claims` in future as well for b/c but imo it would be cleaner to change the serialization key as well when we discard the whole concept of claims.

See #82 and #120 