### PR TITLE
Fix minor style and formatting issues

### DIFF
--- a/src/Deserializers/ClaimsDeserializer.php
+++ b/src/Deserializers/ClaimsDeserializer.php
@@ -63,4 +63,5 @@ class ClaimsDeserializer implements Deserializer {
 			}
 		}
 	}
+
 }

--- a/src/Deserializers/EntityIdDeserializer.php
+++ b/src/Deserializers/EntityIdDeserializer.php
@@ -50,4 +50,5 @@ class EntityIdDeserializer implements Deserializer {
 			throw new DeserializationException( 'The serialization of an entity ID should be a string' );
 		}
 	}
+
 }

--- a/src/Deserializers/FingerprintDeserializer.php
+++ b/src/Deserializers/FingerprintDeserializer.php
@@ -6,7 +6,6 @@ use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
 use Deserializers\Exceptions\MissingAttributeException;
-use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\Fingerprint;
 use Wikibase\DataModel\Term\TermList;
 
@@ -134,9 +133,9 @@ class FingerprintDeserializer implements Deserializer {
 			throw new InvalidAttributeException(
 				$attributeName,
 				$array[$attributeName],
-				"The internal type of attribute '$attributeName'  needs to be '$internalType'"
+				"The internal type of attribute '$attributeName' needs to be '$internalType'"
 			);
 		}
 	}
-	
+
 }

--- a/src/Deserializers/ReferenceDeserializer.php
+++ b/src/Deserializers/ReferenceDeserializer.php
@@ -79,7 +79,7 @@ class ReferenceDeserializer implements DispatchableDeserializer {
 
 	private function assertCanDeserialize( $serialization ) {
 		if ( !$this->isValidSerialization( $serialization ) ) {
-			throw new DeserializationException( 'The serialization is invalid!' );
+			throw new DeserializationException( 'The serialization is invalid' );
 		}
 	}
 

--- a/src/Deserializers/ReferenceListDeserializer.php
+++ b/src/Deserializers/ReferenceListDeserializer.php
@@ -52,7 +52,8 @@ class ReferenceListDeserializer implements Deserializer {
 
 	private function assertIsArray( $serialization ) {
 		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'The ReferenceList serialization should be an array!' );
+			throw new DeserializationException( 'The ReferenceList serialization should be an array' );
 		}
 	}
+
 }

--- a/src/Deserializers/SiteLinkDeserializer.php
+++ b/src/Deserializers/SiteLinkDeserializer.php
@@ -98,4 +98,5 @@ class SiteLinkDeserializer implements Deserializer {
 			throw new MissingAttributeException( $attribute );
 		}
 	}
+
 }

--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -63,4 +63,5 @@ class SnakListDeserializer implements Deserializer {
 			}
 		}
 	}
+
 }

--- a/src/Serializers/ReferenceSerializer.php
+++ b/src/Serializers/ReferenceSerializer.php
@@ -53,7 +53,7 @@ class ReferenceSerializer implements DispatchableSerializer {
 		if ( !$this->isSerializerFor( $object ) ) {
 			throw new UnsupportedObjectException(
 				$object,
-				'ReferenceSerializer can only serialize References objects'
+				'ReferenceSerializer can only serialize Reference objects'
 			);
 		}
 

--- a/tests/integration/ClaimsSerializationRoundtripTest.php
+++ b/tests/integration/ClaimsSerializationRoundtripTest.php
@@ -66,4 +66,5 @@ class ClaimsSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 			),
 		);
 	}
+
 }

--- a/tests/integration/ReferenceSerializationRoundtripTest.php
+++ b/tests/integration/ReferenceSerializationRoundtripTest.php
@@ -53,4 +53,5 @@ class ReferenceSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 			),
 		);
 	}
+
 }

--- a/tests/integration/ReferencesSerializationRoundtripTest.php
+++ b/tests/integration/ReferencesSerializationRoundtripTest.php
@@ -63,4 +63,5 @@ class ReferencesSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	public function assertReferenceListEquals( ReferenceList $expected, ReferenceList $actual ) {
 		$this->assertTrue( $actual->equals( $expected ), 'The two ReferenceList are different' );
 	}
+
 }

--- a/tests/integration/SiteLinkSerializationRoundtripTest.php
+++ b/tests/integration/SiteLinkSerializationRoundtripTest.php
@@ -49,4 +49,5 @@ class SiteLinkSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 			)
 		);
 	}
+
 }

--- a/tests/integration/SnaksSerializationRoundtripTest.php
+++ b/tests/integration/SnaksSerializationRoundtripTest.php
@@ -59,4 +59,5 @@ class SnaksSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 			),
 		);
 	}
+
 }

--- a/tests/unit/Deserializers/ClaimDeserializerTest.php
+++ b/tests/unit/Deserializers/ClaimDeserializerTest.php
@@ -43,7 +43,6 @@ class ClaimDeserializerTest extends DeserializerBaseTest {
 				new PropertyNoValueSnak( 42 )
 			) ) ) );
 
-
 		$referencesDeserializerMock = $this->getMock( '\Deserializers\Deserializer' );
 		$referencesDeserializerMock->expects( $this->any() )
 			->method( 'deserialize' )

--- a/tests/unit/Deserializers/ClaimsDeserializerTest.php
+++ b/tests/unit/Deserializers/ClaimsDeserializerTest.php
@@ -125,4 +125,5 @@ class ClaimsDeserializerTest extends DeserializerBaseTest {
 			),
 		);
 	}
+
 }

--- a/tests/unit/Deserializers/DeserializerBaseTest.php
+++ b/tests/unit/Deserializers/DeserializerBaseTest.php
@@ -35,7 +35,7 @@ abstract class DeserializerBaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @return mixed[] things that are deserialized by the deserializer
+	 * @return array[] things that are deserialized by the deserializer
 	 */
 	public abstract function deserializableProvider();
 
@@ -69,7 +69,7 @@ abstract class DeserializerBaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @return mixed[] things that aren't deserialized by the deserializer
+	 * @return array[] things that aren't deserialized by the deserializer
 	 */
 	public abstract function nonDeserializableProvider();
 
@@ -84,7 +84,8 @@ abstract class DeserializerBaseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @return array an array of array( object deserialized, serialization)
+	 * @return array[] an array of array( object deserialized, serialization )
 	 */
 	public abstract function deserializationProvider();
+
 }

--- a/tests/unit/Deserializers/EntityDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityDeserializerTest.php
@@ -33,7 +33,7 @@ class EntityDeserializerTest extends DeserializerBaseTest {
 		$fingerprintDeserializerMock->expects( $this->any() )
 			->method( 'deserialize' )
 			->will( $this->returnValue( new Fingerprint() ) );
-		
+
 		$statement = new Statement( new Claim( new PropertyNoValueSnak( 42 ) ) );
 		$statement->setGuid( 'test' );
 

--- a/tests/unit/Deserializers/FingerprintDeserializerTest.php
+++ b/tests/unit/Deserializers/FingerprintDeserializerTest.php
@@ -270,6 +270,4 @@ class FingerprintDeserializerTest extends DeserializerBaseTest {
 		);
 	}
 
-
 }
-

--- a/tests/unit/Deserializers/PropertyDeserializerTest.php
+++ b/tests/unit/Deserializers/PropertyDeserializerTest.php
@@ -46,7 +46,6 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			) ) )
 			->will( $this->returnValue( new StatementList( array( $statement ) ) ) );
 
-
 		return new PropertyDeserializer( $entityIdDeserializerMock, $fingerprintDeserializerMock, $statementListDeserializerMock );
 	}
 

--- a/tests/unit/Deserializers/ReferenceListDeserializerTest.php
+++ b/tests/unit/Deserializers/ReferenceListDeserializerTest.php
@@ -101,4 +101,5 @@ class ReferenceListDeserializerTest extends DeserializerBaseTest {
 	public function assertReferenceListEquals( ReferenceList $expected, ReferenceList $actual ) {
 		$this->assertTrue( $actual->equals( $expected ), 'The two ReferenceList are different' );
 	}
+
 }

--- a/tests/unit/Deserializers/SnakListDeserializerTest.php
+++ b/tests/unit/Deserializers/SnakListDeserializerTest.php
@@ -99,4 +99,5 @@ class SnakListDeserializerTest extends DeserializerBaseTest {
 			),
 		);
 	}
+
 }

--- a/tests/unit/Deserializers/StatementListDeserializerTest.php
+++ b/tests/unit/Deserializers/StatementListDeserializerTest.php
@@ -126,4 +126,5 @@ class StatementListDeserializerTest extends DeserializerBaseTest {
 			),
 		);
 	}
+
 }

--- a/tests/unit/Serializers/ReferenceListSerializerTest.php
+++ b/tests/unit/Serializers/ReferenceListSerializerTest.php
@@ -78,4 +78,5 @@ class ReferenceListSerializerTest extends SerializerBaseTest {
 			),
 		);
 	}
+
 }

--- a/tests/unit/Serializers/ReferenceSerializerTest.php
+++ b/tests/unit/Serializers/ReferenceSerializerTest.php
@@ -98,4 +98,5 @@ class ReferenceSerializerTest extends SerializerBaseTest {
 			$referenceSerializer->serialize( $reference )
 		);
 	}
+
 }

--- a/tests/unit/Serializers/SiteLinkSerializerTest.php
+++ b/tests/unit/Serializers/SiteLinkSerializerTest.php
@@ -78,4 +78,5 @@ class SiteLinkSerializerTest extends SerializerBaseTest {
 			),
 		);
 	}
+
 }

--- a/tests/unit/Serializers/SnakSerializerTest.php
+++ b/tests/unit/Serializers/SnakSerializerTest.php
@@ -82,4 +82,5 @@ class SnakSerializerTest extends SerializerBaseTest {
 			),
 		);
 	}
+
 }


### PR DESCRIPTION
* Newlines.
* Unused imports.
* Consistent wording of exception messages.
* Providers can't return anything but an array of arrays, even "invalid" providers must do that.