### PR TITLE
More specific type hints in Serializers

### DIFF
--- a/src/Serializers/ClaimSerializer.php
+++ b/src/Serializers/ClaimSerializer.php
@@ -65,7 +65,7 @@ class ClaimSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Claim $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/ClaimsSerializer.php
+++ b/src/Serializers/ClaimsSerializer.php
@@ -50,7 +50,7 @@ class ClaimsSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Claims $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/ItemSerializer.php
+++ b/src/Serializers/ItemSerializer.php
@@ -69,7 +69,7 @@ class ItemSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Item $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/PropertySerializer.php
+++ b/src/Serializers/PropertySerializer.php
@@ -50,7 +50,7 @@ class PropertySerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Property $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/ReferenceListSerializer.php
+++ b/src/Serializers/ReferenceListSerializer.php
@@ -42,7 +42,7 @@ class ReferenceListSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param ReferenceList $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/ReferenceSerializer.php
+++ b/src/Serializers/ReferenceSerializer.php
@@ -44,7 +44,7 @@ class ReferenceSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Reference $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/SiteLinkSerializer.php
+++ b/src/Serializers/SiteLinkSerializer.php
@@ -30,7 +30,7 @@ class SiteLinkSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param SiteLink $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/SnakSerializer.php
+++ b/src/Serializers/SnakSerializer.php
@@ -43,7 +43,7 @@ class SnakSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Snak $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/SnaksSerializer.php
+++ b/src/Serializers/SnaksSerializer.php
@@ -50,7 +50,7 @@ class SnaksSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param Snaks $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/StatementListSerializer.php
+++ b/src/Serializers/StatementListSerializer.php
@@ -50,7 +50,7 @@ class StatementListSerializer implements DispatchableSerializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param StatementList $object
 	 *
 	 * @return array
 	 * @throws SerializationException

--- a/src/Serializers/TypedSnakSerializer.php
+++ b/src/Serializers/TypedSnakSerializer.php
@@ -30,7 +30,7 @@ class TypedSnakSerializer implements Serializer {
 	/**
 	 * @see Serializer::serialize
 	 *
-	 * @param mixed $object
+	 * @param TypedSnak $object
 	 *
 	 * @return array
 	 * @throws SerializationException


### PR DESCRIPTION
All these parameters must be of this type, otherwise the call throws an exception. It's guaranteed to do so. This is part of the public interface. So this has nothing to do with "package private" or something.