### PR TITLE
More specific type hints in Deserializers

### DIFF
--- a/src/Deserializers/ClaimDeserializer.php
+++ b/src/Deserializers/ClaimDeserializer.php
@@ -69,9 +69,9 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return Claim|Statement
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/ClaimsDeserializer.php
+++ b/src/Deserializers/ClaimsDeserializer.php
@@ -29,9 +29,9 @@ class ClaimsDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return Claims
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/EntityDeserializer.php
+++ b/src/Deserializers/EntityDeserializer.php
@@ -52,9 +52,9 @@ abstract class EntityDeserializer extends TypedObjectDeserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return Entity
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/EntityIdDeserializer.php
+++ b/src/Deserializers/EntityIdDeserializer.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Deserializers;
 
 use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
+use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdParsingException;
 
@@ -30,9 +31,9 @@ class EntityIdDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param string $serialization
 	 *
-	 * @return object
+	 * @return EntityId
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/FingerprintDeserializer.php
+++ b/src/Deserializers/FingerprintDeserializer.php
@@ -21,9 +21,9 @@ class FingerprintDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return Fingerprint
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/ReferenceDeserializer.php
+++ b/src/Deserializers/ReferenceDeserializer.php
@@ -46,9 +46,9 @@ class ReferenceDeserializer implements DispatchableDeserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return Reference
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/ReferenceListDeserializer.php
+++ b/src/Deserializers/ReferenceListDeserializer.php
@@ -29,9 +29,9 @@ class ReferenceListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return ReferenceList
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/SiteLinkDeserializer.php
+++ b/src/Deserializers/SiteLinkDeserializer.php
@@ -32,9 +32,9 @@ class SiteLinkDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return SiteLink
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -14,6 +14,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\DataModel\Snak\Snak;
 
 /**
  * Package private
@@ -67,9 +68,9 @@ class SnakDeserializer implements DispatchableDeserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return Snak
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -29,9 +29,9 @@ class SnakListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return SnakList
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {

--- a/src/Deserializers/StatementListDeserializer.php
+++ b/src/Deserializers/StatementListDeserializer.php
@@ -29,9 +29,9 @@ class StatementListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param mixed $serialization
+	 * @param array $serialization
 	 *
-	 * @return object
+	 * @return StatementList
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {


### PR DESCRIPTION
All these parameters and return types must be of this type, otherwise the call throws an exception. It's guaranteed to do so. This is part of the public interface. So this has nothing to do with "package private" or something.