### PR TITLE
Add missing exceptions to FingerprintDeserializer

### DIFF
--- a/src/Deserializers/FingerprintDeserializer.php
+++ b/src/Deserializers/FingerprintDeserializer.php
@@ -14,7 +14,9 @@ use Wikibase\DataModel\Term\TermList;
  * Package private
  *
  * @licence GNU GPL v2+
+ * @author Thomas Pellissier Tanon
  * @author Bene* < benestar.wikimedia@gmail.com >
+ * @author Thiemo Mättig
  */
 class FingerprintDeserializer implements Deserializer {
 
@@ -27,6 +29,10 @@ class FingerprintDeserializer implements Deserializer {
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'Fingerprint serialization must be an array' );
+		}
+
 		$fingerprint = new Fingerprint();
 
 		$this->setLabelsFromSerialization( $serialization, $fingerprint );
@@ -105,7 +111,7 @@ class FingerprintDeserializer implements Deserializer {
 		}
 	}
 
-	private function assertRequestedAndActualLanguageMatch( $serialization, $requestedLanguage ) {
+	private function assertRequestedAndActualLanguageMatch( array $serialization, $requestedLanguage ) {
 		if ( $serialization['language'] !== $requestedLanguage ) {
 			throw new DeserializationException(
 				'Deserialization of a value of the attribute language (actual)'
@@ -116,6 +122,10 @@ class FingerprintDeserializer implements Deserializer {
 	}
 
 	private function assertIsValidValueSerialization( $serialization, $requestedLanguage ) {
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'Term serializations must be arrays' );
+		}
+
 		$this->requireAttribute( $serialization, 'language' );
 		$this->requireAttribute( $serialization, 'value' );
 		$this->assertNotAttribute( $serialization, 'source' );

--- a/tests/unit/Deserializers/DeserializerBaseTest.php
+++ b/tests/unit/Deserializers/DeserializerBaseTest.php
@@ -57,15 +57,8 @@ abstract class DeserializerBaseTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider nonDeserializableProvider
 	 */
 	public function testSerializeThrowsUnsupportedObjectException( $nonSerializable ) {
-		$deserializer = $this->buildDeserializer();
-
-		if ( $deserializer instanceof DispatchableDeserializer ) {
-			$this->setExpectedException( 'Deserializers\Exceptions\DeserializationException' );
-			$deserializer->deserialize( $nonSerializable );
-		}
-		else {
-			$this->assertTrue( true );
-		}
+		$this->setExpectedException( 'Deserializers\Exceptions\DeserializationException' );
+		$this->buildDeserializer()->deserialize( $nonSerializable );
 	}
 
 	/**

--- a/tests/unit/Deserializers/FingerprintDeserializerTest.php
+++ b/tests/unit/Deserializers/FingerprintDeserializerTest.php
@@ -10,7 +10,9 @@ use Wikibase\DataModel\Term\Fingerprint;
  * @covers Wikibase\DataModel\Deserializers\FingerprintDeserializer
  *
  * @licence GNU GPL v2+
+ * @author Thomas Pellissier Tanon
  * @author Bene* < benestar.wikimedia@gmail.com >
+ * @author Thiemo Mättig
  */
 class FingerprintDeserializerTest extends DeserializerBaseTest {
 
@@ -32,7 +34,19 @@ class FingerprintDeserializerTest extends DeserializerBaseTest {
 	public function nonDeserializableProvider() {
 		return array(
 			array(
-				array()
+				5
+			),
+			array(
+				array( 'labels' => array( 5 ) )
+			),
+			array(
+				array( 'descriptions' => array( 5 ) )
+			),
+			array(
+				array( 'aliases' => array( 5 ) )
+			),
+			array(
+				array( 'aliases' => array( 'en' => array( 5 ) ) )
 			),
 		);
 	}


### PR DESCRIPTION
This fixes an older issue already present before #122 and also reverts parts of #122, see my comments there.