### PR TITLE
Remove redundant typehint

### DIFF
--- a/src/Deserializers/ClaimDeserializer.php
+++ b/src/Deserializers/ClaimDeserializer.php
@@ -71,7 +71,7 @@ class ClaimDeserializer implements DispatchableDeserializer {
 	 *
 	 * @param array $serialization
 	 *
-	 * @return Claim|Statement
+	 * @return Claim
 	 * @throws DeserializationException
 	 */
 	public function deserialize( $serialization ) {


### PR DESCRIPTION
In DataModel 2.6, `Statement` is still a subclass of `Claim` and thus doesn't need to be mentioned here.