### PR TITLE
Make FingerprintSerializer methods private

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -5,7 +5,6 @@ namespace Wikibase\DataModel;
 use Deserializers\Deserializer;
 use Deserializers\DispatchableDeserializer;
 use Deserializers\DispatchingDeserializer;
-use Wikibase\DataModel\Deserializers\StatementDeserializer;
 use Wikibase\DataModel\Deserializers\ClaimsDeserializer;
 use Wikibase\DataModel\Deserializers\EntityIdDeserializer;
 use Wikibase\DataModel\Deserializers\FingerprintDeserializer;
@@ -16,6 +15,7 @@ use Wikibase\DataModel\Deserializers\ReferenceListDeserializer;
 use Wikibase\DataModel\Deserializers\SiteLinkDeserializer;
 use Wikibase\DataModel\Deserializers\SnakDeserializer;
 use Wikibase\DataModel\Deserializers\SnakListDeserializer;
+use Wikibase\DataModel\Deserializers\StatementDeserializer;
 use Wikibase\DataModel\Deserializers\StatementListDeserializer;
 use Wikibase\DataModel\Entity\EntityIdParser;
 

--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -14,7 +14,6 @@ use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
-use Wikibase\DataModel\Snak\Snak;
 
 /**
  * Package private

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -5,7 +5,6 @@ namespace Wikibase\DataModel;
 use InvalidArgumentException;
 use Serializers\DispatchingSerializer;
 use Serializers\Serializer;
-use Wikibase\DataModel\Serializers\StatementSerializer;
 use Wikibase\DataModel\Serializers\ClaimsSerializer;
 use Wikibase\DataModel\Serializers\FingerprintSerializer;
 use Wikibase\DataModel\Serializers\ItemSerializer;
@@ -13,9 +12,10 @@ use Wikibase\DataModel\Serializers\PropertySerializer;
 use Wikibase\DataModel\Serializers\ReferenceListSerializer;
 use Wikibase\DataModel\Serializers\ReferenceSerializer;
 use Wikibase\DataModel\Serializers\SiteLinkSerializer;
-use Wikibase\DataModel\Serializers\SnakSerializer;
 use Wikibase\DataModel\Serializers\SnakListSerializer;
+use Wikibase\DataModel\Serializers\SnakSerializer;
 use Wikibase\DataModel\Serializers\StatementListSerializer;
+use Wikibase\DataModel\Serializers\StatementSerializer;
 use Wikibase\DataModel\Serializers\TypedSnakSerializer;
 
 /**

--- a/src/Serializers/FingerprintSerializer.php
+++ b/src/Serializers/FingerprintSerializer.php
@@ -39,7 +39,7 @@ class FingerprintSerializer {
 		$this->addAliasesToSerialization( $fingerprint->getAliasGroups(), $serialization );
 	}
 
-	public function addIdToSerialization( EntityId $id = null, array &$serialization ) {
+	private function addIdToSerialization( EntityId $id = null, array &$serialization ) {
 		if ( $id === null ) {
 			return;
 		}
@@ -47,7 +47,7 @@ class FingerprintSerializer {
 		$serialization['id'] = $id->getSerialization();
 	}
 
-	public function addLabelsToSerialization( TermList $labels, array &$serialization ) {
+	private function addLabelsToSerialization( TermList $labels, array &$serialization ) {
 		$serialization['labels'] = $this->serializeValuePerTermList( $labels );
 	}
 

--- a/src/Serializers/PropertySerializer.php
+++ b/src/Serializers/PropertySerializer.php
@@ -66,25 +66,25 @@ class PropertySerializer implements DispatchableSerializer {
 		return $this->getSerialized( $object );
 	}
 
-	private function getSerialized( Property $entity ) {
+	private function getSerialized( Property $property ) {
 		$serialization = array(
-			'type' => $entity->getType(),
-			'datatype' => $entity->getDataTypeId(),
+			'type' => $property->getType(),
+			'datatype' => $property->getDataTypeId(),
 		);
 
 		$this->fingerprintSerializer->addBasicsToSerialization(
-			$entity->getId(),
-			$entity->getFingerprint(),
+			$property->getId(),
+			$property->getFingerprint(),
 			$serialization
 		);
 
-		$this->addStatementListToSerialization( $entity, $serialization );
+		$this->addStatementListToSerialization( $property, $serialization );
 
 		return $serialization;
 	}
 
-	private function addStatementListToSerialization( Property $entity, array &$serialization ) {
-		$serialization['claims'] = $this->statementListSerializer->serialize( $entity->getStatements() );
+	private function addStatementListToSerialization( Property $property, array &$serialization ) {
+		$serialization['claims'] = $this->statementListSerializer->serialize( $property->getStatements() );
 	}
 
 }

--- a/tests/unit/Serializers/FingerprintSerializerTest.php
+++ b/tests/unit/Serializers/FingerprintSerializerTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Wikibase\DataModel\Serializers;
 
-use stdClass;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Serializers\FingerprintSerializer;
@@ -11,7 +10,6 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Term\AliasGroupFallback;
 use Wikibase\DataModel\Term\AliasGroupList;
-use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermFallback;
 use Wikibase\DataModel\Term\TermList;
 


### PR DESCRIPTION
This fixes two issues mentioned in #137:
* Make methods private if not used from outside the class.
* Rename $entity to $property.

Also:
* Optimize imports.