### PR TITLE
Add Serialization option for snak hashes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,14 @@
 # Wikibase DataModel Serialization release notes
 
+## 1.7.0 (development)
+
+* Added `SerializerFactory` option `OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH`
+* Added `SerializerFactory` option `OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH`
+* Added `SerializerFactory` option `OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH`
+* Added parameter to `newSnakListSerializer` called `$serializeSnaksWithHash`, the default is b/c
+* Added parameter to `newSnakSerializer` called $serializeWithHash`, the default is b/c
+* Added parameter to `newTypedSnakSerializer` called `$serializeWithHash`, the default is b/c
+
 ## 1.6.0 (2015-07-20)
 
 * Added `newAliasGroupSerializer` to `SerializerFactory`

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -73,7 +73,7 @@ class SerializerFactory {
 	 * @return bool
 	 */
 	private function shouldSerializeSnaksWithHash() {
-		return !(bool)( $this->options & self::OPTION_OBJECTS_FOR_MAPS );
+		return !(bool)( $this->options & self::OPTION_SERIALIZE_SNAKS_WITHOUT_HASH );
 	}
 
 	/**

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -29,11 +29,13 @@ use Wikibase\DataModel\Serializers\TypedSnakSerializer;
  * @licence GNU GPL v2+
  * @author Thomas Pellissier Tanon
  * @author Bene* < benestar.wikimedia@gmail.com >
+ * @author Adam Shorland
  */
 class SerializerFactory {
 
 	const OPTION_DEFAULT = 0;
 	const OPTION_OBJECTS_FOR_MAPS = 1;
+	const OPTION_SERIALIZE_SNAKS_WITHOUT_HASH = 2;
 
 	/**
 	 * @var int
@@ -65,6 +67,13 @@ class SerializerFactory {
 	 */
 	private function shouldUseObjectsForMaps() {
 		return (bool)( $this->options & self::OPTION_OBJECTS_FOR_MAPS );
+	}
+
+	/**
+	 * @return bool
+	 */
+	private function shouldSerializeSnaksWithHash() {
+		return !(bool)( $this->options & self::OPTION_OBJECTS_FOR_MAPS );
 	}
 
 	/**
@@ -192,7 +201,10 @@ class SerializerFactory {
 	 * @return Serializer
 	 */
 	public function newSnakSerializer() {
-		return new SnakSerializer( $this->dataValueSerializer );
+		return new SnakSerializer(
+			$this->dataValueSerializer,
+			$this->shouldSerializeSnaksWithHash()
+		);
 	}
 
 	/**

--- a/src/Serializers/SnakSerializer.php
+++ b/src/Serializers/SnakSerializer.php
@@ -14,6 +14,7 @@ use Wikibase\DataModel\Snak\Snak;
  *
  * @licence GNU GPL v2+
  * @author Thomas Pellissier Tanon
+ * @author Adam Shorland
  */
 class SnakSerializer implements DispatchableSerializer {
 
@@ -23,10 +24,17 @@ class SnakSerializer implements DispatchableSerializer {
 	private $dataValueSerializer;
 
 	/**
-	 * @param Serializer $dataValueSerializer
+	 * @var bool
 	 */
-	public function __construct( Serializer $dataValueSerializer ) {
+	private $serializeSnaksWithHash;
+
+	/**
+	 * @param Serializer $dataValueSerializer
+	 * @param bool $serializeSnaksWithHash
+	 */
+	public function __construct( Serializer $dataValueSerializer, $serializeSnaksWithHash = true ) {
 		$this->dataValueSerializer = $dataValueSerializer;
+		$this->serializeSnaksWithHash = $serializeSnaksWithHash;
 	}
 
 	/**
@@ -63,8 +71,11 @@ class SnakSerializer implements DispatchableSerializer {
 		$serialization = array(
 			'snaktype' => $snak->getType(),
 			'property' => $snak->getPropertyId()->getSerialization(),
-			'hash' => $snak->getHash()
 		);
+
+		if ( $this->serializeSnaksWithHash ) {
+			$serialization['hash'] = $snak->getHash();
+		}
 
 		if ( $snak instanceof PropertyValueSnak ) {
 			$serialization['datavalue'] = $this->dataValueSerializer->serialize( $snak->getDataValue() );

--- a/src/Serializers/SnakSerializer.php
+++ b/src/Serializers/SnakSerializer.php
@@ -26,15 +26,15 @@ class SnakSerializer implements DispatchableSerializer {
 	/**
 	 * @var bool
 	 */
-	private $serializeSnaksWithHash;
+	private $serializeWithHash;
 
 	/**
 	 * @param Serializer $dataValueSerializer
-	 * @param bool $serializeSnaksWithHash
+	 * @param bool $serializeWithHash
 	 */
-	public function __construct( Serializer $dataValueSerializer, $serializeSnaksWithHash = true ) {
+	public function __construct( Serializer $dataValueSerializer, $serializeWithHash = true ) {
 		$this->dataValueSerializer = $dataValueSerializer;
-		$this->serializeSnaksWithHash = $serializeSnaksWithHash;
+		$this->serializeWithHash = $serializeWithHash;
 	}
 
 	/**
@@ -73,7 +73,7 @@ class SnakSerializer implements DispatchableSerializer {
 			'property' => $snak->getPropertyId()->getSerialization(),
 		);
 
-		if ( $this->serializeSnaksWithHash ) {
+		if ( $this->serializeWithHash ) {
 			$serialization['hash'] = $snak->getHash();
 		}
 

--- a/src/Serializers/StatementSerializer.php
+++ b/src/Serializers/StatementSerializer.php
@@ -27,12 +27,12 @@ class StatementSerializer implements DispatchableSerializer {
 	/**
 	 * @var Serializer
 	 */
-	private $snakSerializer;
+	private $mainSnakSerializer;
 
 	/**
 	 * @var Serializer
 	 */
-	private $snaksSerializer;
+	private $qualifierSnaksSerializer;
 
 	/**
 	 * @var Serializer
@@ -40,13 +40,17 @@ class StatementSerializer implements DispatchableSerializer {
 	private $referencesSerializer;
 
 	/**
-	 * @param Serializer $snakSerializer
-	 * @param Serializer $snaksSerializer
+	 * @param Serializer $mainSnakSerializer
+	 * @param Serializer $qualifierSnaksSerializer
 	 * @param Serializer $referencesSerializer
 	 */
-	public function __construct( Serializer $snakSerializer, Serializer $snaksSerializer, Serializer $referencesSerializer ) {
-		$this->snakSerializer = $snakSerializer;
-		$this->snaksSerializer = $snaksSerializer;
+	public function __construct(
+		Serializer $mainSnakSerializer,
+		Serializer $qualifierSnaksSerializer,
+		Serializer $referencesSerializer
+	) {
+		$this->mainSnakSerializer = $mainSnakSerializer;
+		$this->qualifierSnaksSerializer = $qualifierSnaksSerializer;
 		$this->referencesSerializer = $referencesSerializer;
 	}
 
@@ -82,7 +86,7 @@ class StatementSerializer implements DispatchableSerializer {
 
 	private function getSerialized( Statement $statement ) {
 		$serialization = array(
-			'mainsnak' => $this->snakSerializer->serialize( $statement->getMainSnak() ),
+			'mainsnak' => $this->mainSnakSerializer->serialize( $statement->getMainSnak() ),
 			'type' => 'statement'
 		);
 
@@ -109,7 +113,9 @@ class StatementSerializer implements DispatchableSerializer {
 		$references = $statement->getReferences();
 
 		if ( $references->count() != 0 ) {
-			$serialization['references'] = $this->referencesSerializer->serialize( $statement->getReferences() );
+			$serialization['references'] = $this->referencesSerializer->serialize(
+				$statement->getReferences()
+			);
 		}
 	}
 
@@ -117,7 +123,7 @@ class StatementSerializer implements DispatchableSerializer {
 		$qualifiers = $statement->getQualifiers();
 
 		if ( $qualifiers->count() !== 0 ) {
-			$serialization['qualifiers'] = $this->snaksSerializer->serialize( $qualifiers );
+			$serialization['qualifiers'] = $this->qualifierSnaksSerializer->serialize( $qualifiers );
 			$serialization['qualifiers-order'] = $this->buildQualifiersOrderList( $qualifiers );
 		}
 	}

--- a/tests/unit/Serializers/SnakSerializerTest.php
+++ b/tests/unit/Serializers/SnakSerializerTest.php
@@ -83,4 +83,13 @@ class SnakSerializerTest extends SerializerBaseTest {
 		);
 	}
 
+	public function testSnakSerializationWithoutHash() {
+		$serializer = new SnakSerializer( new DataValueSerializer(), false );
+
+		$snak = new PropertyValueSnak( 42, new StringValue( 'hax' ) );
+		$serialization = $serializer->serialize( $snak );
+
+		$this->assertArrayNotHasKey( 'hash', $serialization );
+	}
+
 }


### PR DESCRIPTION
In the current Wikibase Lib serializers there is
an option to serialize snaks without a hash.

This is due to the fact that the hashes are not all
that usefull in the API output.

To avoid adding these hashes to the serialization
this option is needed