### PR TITLE
Support DerivedPropertyValueSnak in SnakSerializer

### DIFF
--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -107,6 +107,8 @@ class SnakDeserializer implements DispatchableDeserializer {
 
 	private function newValueSnak( array $serialization ) {
 		$this->requireAttribute( $serialization, 'datavalue' );
+		// Do not deserialize derived value snaks
+		$this->assertNotAttribute( $serialization, 'derived-values' );
 
 		return new PropertyValueSnak(
 			$this->deserializePropertyId( $serialization['property'] ),
@@ -156,6 +158,16 @@ class SnakDeserializer implements DispatchableDeserializer {
 		if ( !array_key_exists( $attributeName, $array ) ) {
 			throw new MissingAttributeException(
 				$attributeName
+			);
+		}
+	}
+
+	private function assertNotAttribute( array $array, $key ) {
+		if ( array_key_exists( $key, $array ) ) {
+			throw new InvalidAttributeException(
+				$key,
+				$array[$key],
+				'Deserialization of attribute ' . $key . ' not supported.'
 			);
 		}
 	}

--- a/src/Serializers/SnakSerializer.php
+++ b/src/Serializers/SnakSerializer.php
@@ -6,6 +6,7 @@ use Serializers\DispatchableSerializer;
 use Serializers\Exceptions\SerializationException;
 use Serializers\Exceptions\UnsupportedObjectException;
 use Serializers\Serializer;
+use Wikibase\DataModel\Snak\DerivedPropertyValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Snak\Snak;
 
@@ -79,6 +80,12 @@ class SnakSerializer implements DispatchableSerializer {
 
 		if ( $snak instanceof PropertyValueSnak ) {
 			$serialization['datavalue'] = $this->dataValueSerializer->serialize( $snak->getDataValue() );
+		}
+
+		if ( $snak instanceof DerivedPropertyValueSnak ) {
+			foreach ( $snak->getDerivedDataValues() as $key => $dataValue ) {
+				$serialization[$key] = $this->dataValueSerializer->serialize( $dataValue );
+			}
 		}
 
 		return $serialization;

--- a/src/Serializers/SnakSerializer.php
+++ b/src/Serializers/SnakSerializer.php
@@ -84,7 +84,7 @@ class SnakSerializer implements DispatchableSerializer {
 
 		if ( $snak instanceof DerivedPropertyValueSnak ) {
 			foreach ( $snak->getDerivedDataValues() as $key => $dataValue ) {
-				$serialization[$key] = $this->dataValueSerializer->serialize( $dataValue );
+				$serialization['derived-values'][$key] = $this->dataValueSerializer->serialize( $dataValue );
 			}
 		}
 

--- a/src/Serializers/SnakSerializer.php
+++ b/src/Serializers/SnakSerializer.php
@@ -84,7 +84,7 @@ class SnakSerializer implements DispatchableSerializer {
 
 		if ( $snak instanceof DerivedPropertyValueSnak ) {
 			foreach ( $snak->getDerivedDataValues() as $key => $dataValue ) {
-				$serialization['derived-values'][$key] = $this->dataValueSerializer->serialize( $dataValue );
+				$serialization['datavalue-' . $key] = $this->dataValueSerializer->serialize( $dataValue );
 			}
 		}
 

--- a/tests/unit/Deserializers/SnakDeserializerTest.php
+++ b/tests/unit/Deserializers/SnakDeserializerTest.php
@@ -143,6 +143,18 @@ class SnakDeserializerTest extends DeserializerBaseTest {
 					'property' => 'P42'
 				)
 			),
+			array(
+				array(
+					'snaktype' => 'value',
+					'property' => 'P42',
+					'datavalue' => array(
+						'type' => 'string',
+						'value' => 'hax'
+					),
+					'derived-values' => array(
+					)
+				)
+			)
 		);
 	}
 

--- a/tests/unit/Serializers/SnakSerializerTest.php
+++ b/tests/unit/Serializers/SnakSerializerTest.php
@@ -40,7 +40,7 @@ class SnakSerializerTest extends SerializerBaseTest {
 					new PropertyId( 'P42' ),
 					new StringValue( 'foo' ),
 					array(
-						'bar' => new StringValue( 'This is a slotty slot' )
+						'bar' => new StringValue( 'This is a derived value' )
 					)
 				)
 			)
@@ -100,18 +100,16 @@ class SnakSerializerTest extends SerializerBaseTest {
 						'type' => 'string',
 						'value' => 'foo'
 					),
-					'derived-values' => array(
-						'bar' => array(
-							'type' => 'string',
-							'value' => 'This is a slotty slot'
-						)
+					'datavalue-bar' => array(
+						'type' => 'string',
+						'value' => 'This is a derived value'
 					)
 				),
 				new DerivedPropertyValueSnak(
 					new PropertyId( 'P42' ),
 					new StringValue( 'foo' ),
 					array(
-						'bar' => new StringValue( 'This is a slotty slot' )
+						'bar' => new StringValue( 'This is a derived value' )
 					)
 				)
 			)

--- a/tests/unit/Serializers/SnakSerializerTest.php
+++ b/tests/unit/Serializers/SnakSerializerTest.php
@@ -5,7 +5,9 @@ namespace Tests\Wikibase\DataModel\Serializers;
 use DataValues\Serializers\DataValueSerializer;
 use DataValues\StringValue;
 use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Serializers\SnakSerializer;
+use Wikibase\DataModel\Snak\DerivedPropertyValueSnak;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
@@ -33,6 +35,15 @@ class SnakSerializerTest extends SerializerBaseTest {
 			array(
 				new PropertyValueSnak( 42, new StringValue( 'hax' ) )
 			),
+			array(
+				new DerivedPropertyValueSnak(
+					new PropertyId( 'P42' ),
+					new StringValue( 'foo' ),
+					array(
+						'extra' => new StringValue( 'This is a slotty slot' )
+					)
+				)
+			)
 		);
 	}
 
@@ -80,6 +91,28 @@ class SnakSerializerTest extends SerializerBaseTest {
 				),
 				new PropertyValueSnak( 42, new StringValue( 'hax' ) )
 			),
+			array(
+				array(
+					'snaktype' => 'value',
+					'property' => 'P42',
+					'hash' => '861dc9fc32da49df803794037914c6cd6294ed8d',
+					'datavalue' => array(
+						'type' => 'string',
+						'value' => 'foo'
+					),
+					'extra' => array(
+						'type' => 'string',
+						'value' => 'This is a slotty slot'
+					)
+				),
+				new DerivedPropertyValueSnak(
+					new PropertyId( 'P42' ),
+					new StringValue( 'foo' ),
+					array(
+						'extra' => new StringValue( 'This is a slotty slot' )
+					)
+				)
+			)
 		);
 	}
 

--- a/tests/unit/Serializers/SnakSerializerTest.php
+++ b/tests/unit/Serializers/SnakSerializerTest.php
@@ -40,7 +40,7 @@ class SnakSerializerTest extends SerializerBaseTest {
 					new PropertyId( 'P42' ),
 					new StringValue( 'foo' ),
 					array(
-						'extra' => new StringValue( 'This is a slotty slot' )
+						'bar' => new StringValue( 'This is a slotty slot' )
 					)
 				)
 			)
@@ -100,16 +100,18 @@ class SnakSerializerTest extends SerializerBaseTest {
 						'type' => 'string',
 						'value' => 'foo'
 					),
-					'extra' => array(
-						'type' => 'string',
-						'value' => 'This is a slotty slot'
+					'derived-values' => array(
+						'bar' => array(
+							'type' => 'string',
+							'value' => 'This is a slotty slot'
+						)
 					)
 				),
 				new DerivedPropertyValueSnak(
 					new PropertyId( 'P42' ),
 					new StringValue( 'foo' ),
 					array(
-						'extra' => new StringValue( 'This is a slotty slot' )
+						'bar' => new StringValue( 'This is a slotty slot' )
 					)
 				)
 			)


### PR DESCRIPTION
This is a draft how we could support derived data values in `SnakSerializer`. Another option would be to introduce an extra key like `slots` or `derived-values` where we add the extra data values. If we consider using this solution, there might be conflicts with existing keys.
