### PR TITLE
Reduce mentions of Claim(s) without breaking anything

### DIFF
--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -166,7 +166,7 @@ class SerializerFactory {
 	}
 
 	/**
-	 * Returns a Serializer that can serialize claims.
+	 * Returns a Serializer that can serialize Claim objects.
 	 *
 	 * @deprecated since 1.4, use newStatementSerializer instead
 	 *

--- a/src/Serializers/ClaimsSerializer.php
+++ b/src/Serializers/ClaimsSerializer.php
@@ -6,8 +6,8 @@ use Serializers\DispatchableSerializer;
 use Serializers\Exceptions\SerializationException;
 use Serializers\Exceptions\UnsupportedObjectException;
 use Serializers\Serializer;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
+use Wikibase\DataModel\Statement\Statement;
 
 /**
  * Package private
@@ -20,7 +20,7 @@ class ClaimsSerializer implements DispatchableSerializer {
 	/**
 	 * @var Serializer
 	 */
-	private $claimSerializer;
+	private $statementSerializer;
 
 	/**
 	 * @var bool
@@ -28,11 +28,11 @@ class ClaimsSerializer implements DispatchableSerializer {
 	private $useObjectsForMaps;
 
 	/**
-	 * @param Serializer $claimSerializer
+	 * @param Serializer $statementSerializer
 	 * @param bool $useObjectsForMaps
 	 */
-	public function __construct( Serializer $claimSerializer, $useObjectsForMaps ) {
-		$this->claimSerializer = $claimSerializer;
+	public function __construct( Serializer $statementSerializer, $useObjectsForMaps ) {
+		$this->statementSerializer = $statementSerializer;
 		$this->useObjectsForMaps = $useObjectsForMaps;
 	}
 
@@ -66,14 +66,12 @@ class ClaimsSerializer implements DispatchableSerializer {
 		return $this->getSerialized( $object );
 	}
 
-	private function getSerialized( Claims $claims ) {
+	private function getSerialized( Claims $statements ) {
 		$serialization = array();
 
-		/**
-		 * @var Claim $claim
-		 */
-		foreach ( $claims as $claim ) {
-			$serialization[$claim->getMainSnak()->getPropertyId()->getSerialization()][] = $this->claimSerializer->serialize( $claim );
+		/** @var Statement $statement */
+		foreach ( $statements as $statement ) {
+			$serialization[$statement->getMainSnak()->getPropertyId()->getSerialization()][] = $this->statementSerializer->serialize( $statement );
 		}
 
 		if ( $this->useObjectsForMaps ) {

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -4,7 +4,6 @@ namespace Tests\Wikibase\DataModel;
 
 use DataValues\Serializers\DataValueSerializer;
 use Serializers\Serializer;
-use Wikibase\DataModel\Claim\Claim;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\Property;
@@ -15,6 +14,7 @@ use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\SnakList;
 use Wikibase\DataModel\Snak\TypedSnak;
+use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Term\AliasGroup;
 use Wikibase\DataModel\Term\AliasGroupList;
@@ -73,7 +73,7 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 	public function testNewClaimSerializer() {
 		$this->assertSerializesWithoutException(
 			$this->buildSerializerFactory()->newClaimSerializer(),
-			new Claim( new PropertyNoValueSnak( 42 ) )
+			new Statement( new PropertyNoValueSnak( 42 ) )
 		);
 	}
 

--- a/tests/unit/Serializers/AliasGroupListSerializerTest.php
+++ b/tests/unit/Serializers/AliasGroupListSerializerTest.php
@@ -6,7 +6,6 @@ use stdClass;
 use Wikibase\DataModel\Serializers\AliasGroupListSerializer;
 use Wikibase\DataModel\Serializers\TermSerializer;
 use Wikibase\DataModel\Term\AliasGroup;
-use Wikibase\DataModel\Term\AliasGroupFallback;
 use Wikibase\DataModel\Term\AliasGroupList;
 
 /**

--- a/tests/unit/Serializers/ClaimsSerializerTest.php
+++ b/tests/unit/Serializers/ClaimsSerializerTest.php
@@ -20,8 +20,8 @@ class ClaimsSerializerTest extends SerializerBaseTest {
 		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'test' );
 
-		$claimSerializerMock = $this->getMock( '\Serializers\Serializer' );
-		$claimSerializerMock->expects( $this->any() )
+		$statementSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$statementSerializerMock->expects( $this->any() )
 			->method( 'serialize' )
 			->with( $this->equalTo( $statement ) )
 			->will( $this->returnValue( array(
@@ -33,12 +33,12 @@ class ClaimsSerializerTest extends SerializerBaseTest {
 				'rank' => 'normal'
 			) ) );
 
-		return new ClaimsSerializer( $claimSerializerMock, false );
+		return new ClaimsSerializer( $statementSerializerMock, false );
 	}
 
 	public function serializableProvider() {
-		$claim = new Statement( new PropertyNoValueSnak( 42 ) );
-		$claim->setGuid( 'test' );
+		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
+		$statement->setGuid( 'test' );
 
 		return array(
 			array(
@@ -46,7 +46,7 @@ class ClaimsSerializerTest extends SerializerBaseTest {
 			),
 			array(
 				new Claims( array(
-					$claim
+					$statement
 				) )
 			),
 		);
@@ -98,15 +98,15 @@ class ClaimsSerializerTest extends SerializerBaseTest {
 	public function testClaimsSerializerWithOptionObjectsForMaps() {
 		$statement = new Statement( new PropertyNoValueSnak( 42 ) );
 		$statement->setGuid( 'test' );
-		$claimSerializerMock = $this->getMock( '\Serializers\Serializer' );
-		$claimSerializerMock->expects( $this->any() )
+		$statementSerializerMock = $this->getMock( '\Serializers\Serializer' );
+		$statementSerializerMock->expects( $this->any() )
 			->method( 'serialize' )
 			->with( $this->equalTo( $statement ) )
 			->will( $this->returnValue( array(
 				'mockedsuff' => array(),
 				'type' => 'statement',
 			) ) );
-		$serializer = new ClaimsSerializer( $claimSerializerMock, true );
+		$serializer = new ClaimsSerializer( $statementSerializerMock, true );
 
 		$claims = new Claims( array( $statement ) );
 


### PR DESCRIPTION
This is a non-breaking change that should have zero effect to the public interface. The idea is to reduce the occurrences of the word "claim" in this component to a minimum.