### PR TITLE
Revert "Drop dependency on Wikibase DataModel Services"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ The recommended way to use this library is via [Composer](http://getcomposer.org
 To add this package as a local, per-project dependency to your project, simply add a
 dependency on `wikibase/data-model-serialization` to your project's `composer.json` file.
 Here is a minimal example of a `composer.json` file that just defines a dependency on
-version 1.5 of this package:
+version 1.0 of this package:
 
 ```json
 {
 	"require": {
-		"wikibase/data-model-serialization": "~1.7"
+		"wikibase/data-model-serialization": "~1.0"
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ The recommended way to use this library is via [Composer](http://getcomposer.org
 To add this package as a local, per-project dependency to your project, simply add a
 dependency on `wikibase/data-model-serialization` to your project's `composer.json` file.
 Here is a minimal example of a `composer.json` file that just defines a dependency on
-version 1.0 of this package:
+version 1.5 of this package:
 
 ```json
 {
 	"require": {
-		"wikibase/data-model-serialization": "~1.0"
+		"wikibase/data-model-serialization": "~1.7"
 	}
 }
 ```

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Wikibase DataModel Serialization release notes
 
+## 1.9.1 (2015-08-27)
+
+* Revert of breaking changes, will be added in 2.0 again
+
+## 1.9.0 (2015-08-26)
+
+* Dropped dependence on Wikibase DataModel Services
+
 ## 1.8.0 (2015-07-28)
 
 * Added compatibility with Wikibase DataModel 4.x

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,5 @@
 # Wikibase DataModel Serialization release notes
 
-## 1.9.0 (2015-08-26)
-
-* Dropped dependence on Wikibase DataModel Services
-
 ## 1.8.0 (2015-07-28)
 
 * Added compatibility with Wikibase DataModel 4.x

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.8.x-dev"
+			"dev-master": "1.9.x-dev"
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
-		"wikibase/data-model": "~4.2",
+		"wikibase/data-model": "~4.0",
+		"wikibase/data-model-services": "~1.0",
 		"serialization/serialization": "~3.1",
 		"data-values/serialization": "~1.0"
 	},
@@ -48,7 +49,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.9.x-dev"
+			"dev-master": "1.8.x-dev"
 		}
 	},
 	"scripts": {

--- a/mediawiki.php
+++ b/mediawiki.php
@@ -4,7 +4,7 @@ if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['wikibase']['WikibaseDataModelSerialization'] = array(
 		'path' => __DIR__,
 		'name' => 'Wikibase DataModel Serialization',
-		'version' => '1.8.0',
+		'version' => '1.9.1',
 		'author' => array(
 			'[https://github.com/Tpt Thomas PT]',
 			'[https://www.mediawiki.org/wiki/User:Jeroen_De_Dauw Jeroen De Dauw]',

--- a/mediawiki.php
+++ b/mediawiki.php
@@ -4,7 +4,7 @@ if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['wikibase']['WikibaseDataModelSerialization'] = array(
 		'path' => __DIR__,
 		'name' => 'Wikibase DataModel Serialization',
-		'version' => '1.9.0',
+		'version' => '1.8.0',
 		'author' => array(
 			'[https://github.com/Tpt Thomas PT]',
 			'[https://www.mediawiki.org/wiki/User:Jeroen_De_Dauw Jeroen De Dauw]',

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -19,7 +19,7 @@ use Wikibase\DataModel\Deserializers\StatementDeserializer;
 use Wikibase\DataModel\Deserializers\StatementListDeserializer;
 use Wikibase\DataModel\Deserializers\TermDeserializer;
 use Wikibase\DataModel\Deserializers\TermListDeserializer;
-use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Services\EntityId\EntityIdParser;
 
 /**
  * Factory for constructing Deserializer objects that can deserialize WikibaseDataModel objects.

--- a/src/Deserializers/EntityIdDeserializer.php
+++ b/src/Deserializers/EntityIdDeserializer.php
@@ -5,8 +5,8 @@ namespace Wikibase\DataModel\Deserializers;
 use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Wikibase\DataModel\Entity\EntityId;
-use Wikibase\DataModel\Entity\EntityIdParser;
-use Wikibase\DataModel\Entity\EntityIdParsingException;
+use Wikibase\DataModel\Services\EntityId\EntityIdParser;
+use Wikibase\DataModel\Services\EntityId\EntityIdParsingException;
 
 /**
  * Package private

--- a/tests/integration/ClaimsSerializationRoundtripTest.php
+++ b/tests/integration/ClaimsSerializationRoundtripTest.php
@@ -6,7 +6,7 @@ use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\Claim\Claims;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\SerializerFactory;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\Statement;

--- a/tests/integration/EntityDeserializationCompatibilityTest.php
+++ b/tests/integration/EntityDeserializationCompatibilityTest.php
@@ -6,7 +6,7 @@ use DataValues\Deserializers\DataValueDeserializer;
 use Deserializers\Deserializer;
 use SplFileInfo;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 
 /**
  * @group slow

--- a/tests/integration/EntitySerializationRoundtripTest.php
+++ b/tests/integration/EntitySerializationRoundtripTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\Entity;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\ItemId;

--- a/tests/integration/ReferenceSerializationRoundtripTest.php
+++ b/tests/integration/ReferenceSerializationRoundtripTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\SerializerFactory;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;

--- a/tests/integration/ReferencesSerializationRoundtripTest.php
+++ b/tests/integration/ReferencesSerializationRoundtripTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\SerializerFactory;

--- a/tests/integration/SiteLinkSerializationRoundtripTest.php
+++ b/tests/integration/SiteLinkSerializationRoundtripTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\SerializerFactory;
 use Wikibase\DataModel\SiteLink;

--- a/tests/integration/SnakListSerializationRoundtripTest.php
+++ b/tests/integration/SnakListSerializationRoundtripTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\SerializerFactory;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;

--- a/tests/integration/SnakSerializationRoundtripTest.php
+++ b/tests/integration/SnakSerializationRoundtripTest.php
@@ -7,7 +7,7 @@ use DataValues\Serializers\DataValueSerializer;
 use DataValues\StringValue;
 use DataValues\UnDeserializableValue;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\SerializerFactory;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;

--- a/tests/integration/StatementSerializationRoundtripTest.php
+++ b/tests/integration/StatementSerializationRoundtripTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use DataValues\Serializers\DataValueSerializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 use Wikibase\DataModel\SerializerFactory;

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -5,7 +5,7 @@ namespace Tests\Wikibase\DataModel;
 use DataValues\Deserializers\DataValueDeserializer;
 use Deserializers\Deserializer;
 use Wikibase\DataModel\DeserializerFactory;
-use Wikibase\DataModel\Entity\BasicEntityIdParser;
+use Wikibase\DataModel\Services\EntityId\BasicEntityIdParser;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/unit/Deserializers/EntityIdDeserializerTest.php
+++ b/tests/unit/Deserializers/EntityIdDeserializerTest.php
@@ -4,7 +4,7 @@ namespace Tests\Wikibase\DataModel\Deserializers;
 
 use Wikibase\DataModel\Deserializers\EntityIdDeserializer;
 use Wikibase\DataModel\Entity\ItemId;
-use Wikibase\DataModel\Entity\EntityIdParsingException;
+use Wikibase\DataModel\Services\EntityId\EntityIdParsingException;
 
 /**
  * @covers Wikibase\DataModel\Deserializers\EntityIdDeserializer
@@ -15,7 +15,7 @@ use Wikibase\DataModel\Entity\EntityIdParsingException;
 class EntityIdDeserializerTest extends DeserializerBaseTest {
 
 	public function buildDeserializer() {
-		$entityIdParserMock = $this->getMock( '\Wikibase\DataModel\Entity\EntityIdParser' );
+		$entityIdParserMock = $this->getMock( '\Wikibase\DataModel\Services\EntityId\EntityIdParser' );
 		$entityIdParserMock->expects( $this->any() )
 			->method( 'parse' )
 			->with( $this->equalTo( 'Q42' ) )
@@ -53,7 +53,7 @@ class EntityIdDeserializerTest extends DeserializerBaseTest {
 	}
 
 	public function testDeserializeWithEntityIdParsingException() {
-		$entityIdParserMock = $this->getMock( '\Wikibase\DataModel\Entity\EntityIdParser' );
+		$entityIdParserMock = $this->getMock( '\Wikibase\DataModel\Services\EntityId\EntityIdParser' );
 		$entityIdParserMock->expects( $this->any() )
 			->method( 'parse' )
 			->will( $this->throwException( new EntityIdParsingException() ) );


### PR DESCRIPTION
Reverts wmde/WikibaseDataModelSerialization#166

This was a breaking change and should not get released as a 1.9 but a 2.0. We must do a 1.9.1 release which fixes this issue and then release the changes again as 2.0.