### PR TITLE
Favor addNewSiteLink() over addSiteLink( new SiteLink() )

### DIFF
--- a/tests/integration/EntitySerializationRoundtripTest.php
+++ b/tests/integration/EntitySerializationRoundtripTest.php
@@ -65,7 +65,7 @@ class EntitySerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 		$entities[] = array( $entity );
 
 		$item = new Item();
-		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
+		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'Nyan Cat' );
 		$entities[] = array( $item );
 
 		$entities[] = array( Property::newFromType( 'string' ) );

--- a/tests/unit/Deserializers/ItemDeserializerTest.php
+++ b/tests/unit/Deserializers/ItemDeserializerTest.php
@@ -203,7 +203,7 @@ class ItemDeserializerTest extends DeserializerBaseTest {
 		);
 
 		$item = new Item();
-		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
+		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'Nyan Cat' );
 		$provider[] = array(
 			$item,
 			array(

--- a/tests/unit/Serializers/ItemSerializerTest.php
+++ b/tests/unit/Serializers/ItemSerializerTest.php
@@ -224,7 +224,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 		);
 
 		$item = new Item();
-		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
+		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'Nyan Cat' );
 		$provider[] = array(
 			array(
 				'type' => 'item',
@@ -250,7 +250,7 @@ class ItemSerializerTest extends SerializerBaseTest {
 		$serializer = $this->buildSerializer( true );
 
 		$item = new Item();
-		$item->addSiteLink( new SiteLink( 'enwiki', 'Nyan Cat' ) );
+		$item->getSiteLinkList()->addNewSiteLink( 'enwiki', 'Nyan Cat' );
 
 		$sitelinks = new \stdClass();
 		$sitelinks->enwiki = array(


### PR DESCRIPTION
This also avoids calling a deprecated method.