### PR TITLE
Code Experiment: Facet serialization.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.1 (dev)
+
+* Added support for facets
+
 ## 2.0.0 (2015-08-30)
 
 * Dropped dependency on Wikibase DataModel Services

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
-		"wikibase/data-model": "~4.2",
+		"wikimedia/assert": "0.2.2",
+		"wikibase/data-model": "~5.0",
 		"serialization/serialization": "~3.1",
 		"data-values/serialization": "~1.0"
 	},

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -7,6 +7,7 @@ use Deserializers\DispatchableDeserializer;
 use Deserializers\DispatchingDeserializer;
 use Wikibase\DataModel\Deserializers\AliasGroupListDeserializer;
 use Wikibase\DataModel\Deserializers\EntityIdDeserializer;
+use Wikibase\DataModel\Deserializers\FailingDeserializer;
 use Wikibase\DataModel\Deserializers\ItemDeserializer;
 use Wikibase\DataModel\Deserializers\PropertyDeserializer;
 use Wikibase\DataModel\Deserializers\ReferenceDeserializer;
@@ -19,6 +20,7 @@ use Wikibase\DataModel\Deserializers\StatementListDeserializer;
 use Wikibase\DataModel\Deserializers\TermDeserializer;
 use Wikibase\DataModel\Deserializers\TermListDeserializer;
 use Wikibase\DataModel\Entity\EntityIdParser;
+use Wikibase\DataModel\Serializers\FacetContainerDeserializer;
 
 /**
  * Factory for constructing Deserializer objects that can deserialize WikibaseDataModel objects.
@@ -163,7 +165,17 @@ class DeserializerFactory {
 	 * @return Deserializer
 	 */
 	public function newTermDeserializer() {
-		return new TermDeserializer();
+		//TODO: get facet deserializers from a central registry or hook, so extensions can add their own
+		$facetDeserializers = array(
+			// Depending on context, we may or may not allow language fallback
+			//'LanguageFallbackInfo' => new LanguageFallbackInfoDeserializer(),
+			'LanguageFallbackInfo' => new FailingDeserializer(
+				array( 'source' ),
+				'Refused deserialization of terms with language fallback applied'
+			),
+		);
+
+		return new TermDeserializer( new FacetContainerDeserializer( $facetDeserializers ) );
 	}
 
 	/**

--- a/src/Deserializers/FacetContainerDeserializer.php
+++ b/src/Deserializers/FacetContainerDeserializer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wikibase\DataModel\Serializers;
+
+use Deserializers\DispatchableDeserializer;
+use Wikibase\DataModel\Facet\FacetContainer;
+use Wikimedia\Assert\Assert;
+
+/**
+ * Package private
+ *
+ * @since 2.1
+ *
+ * @licence GNU GPL v2+
+ * @author Daniel Kinzler
+ */
+class FacetContainerDeserializer  {
+
+	/**
+	 * @var DispatchableDeserializer[] by facet name
+	 */
+	private $deserializers;
+
+	/**
+	 * @param DispatchableDeserializer[] $deserializers
+	 */
+	public function __construct( array $deserializers ) {
+		Assert::parameterElementType( 'Deserializers\DispatchableDeserializer', $deserializers, '$deserializers' );
+
+		$this->deserializers = $deserializers;
+	}
+
+	/**
+	 * @param FacetContainer $object The object to add facets to.
+	 * @param array $data Serialized data to deserialize
+	 */
+	public function deserializeFacets( FacetContainer $object, array $data ) {
+		foreach ( $this->deserializers as $name => $deserializer ) {
+			if ( $deserializer->isDeserializerFor( $data ) ) {
+				$facet = $deserializer->deserialize( $data );
+				$object->addFacet( $name, $facet );
+			}
+		}
+	}
+
+}

--- a/src/Deserializers/FailingDeserializer.php
+++ b/src/Deserializers/FailingDeserializer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Wikibase\DataModel\Deserializers;
+
+use Deserializers\Deserializer;
+use Deserializers\Exceptions\DeserializationException;
+use Wikibase\DataModel\Term\Term;
+use Wikimedia\Assert\Assert;
+
+/**
+ * A Deserializer that fails when certain fields are present in the serialization.
+ * This can be used to prevent ingestion of certain data structures.
+ *
+ * @since 2.1
+ *
+ * @licence GNU GPL v2+
+ * @author Daniel Kinzler
+ */
+class FailingDeserializer implements Deserializer {
+
+	/**
+	 * @var string[]
+	 */
+	private $fields;
+
+	/**
+	 * @var string
+	 */
+	private $message;
+
+	/**
+	 * @param string[] $fields
+	 * @param $message
+	 */
+	public function __construct( array $fields, $message ) {
+		Assert::parameterElementType( 'string', $fields, '$fields' );
+		Assert::parameterType( 'string', $message, '$message' );
+
+		$this->fields = $fields;
+		$this->message = $message;
+	}
+
+	/**
+	 * @param mixed $serialization
+	 *
+	 * @return Term
+	 * @throws DeserializationException
+	 */
+	public function deserialize( $serialization ) {
+		foreach ( $this->fields as $field ) {
+			if ( !array_key_exists( $field, $serialization ) ) {
+				return;
+			}
+		}
+
+		throw new DeserializationException( $this->message );
+	}
+
+}

--- a/src/Deserializers/LanguageFallbackInfoDeserializer.php
+++ b/src/Deserializers/LanguageFallbackInfoDeserializer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Wikibase\DataModel\Deserializers;
+
+use Deserializers\DispatchableDeserializer;
+use Deserializers\Exceptions\DeserializationException;
+use Wikibase\DataModel\Term\LanguageFallbackInfo;
+use Wikibase\DataModel\Term\Term;
+
+/**
+ * Package private
+ *
+ * @since 2.1
+ *
+ * @licence GNU GPL v2+
+ * @author Daniel Kinzler
+ */
+class LanguageFallbackInfoDeserializer implements DispatchableDeserializer {
+
+	/**
+	 * @param mixed $serialization
+	 *
+	 * @return Term
+	 * @throws DeserializationException
+	 */
+	public function deserialize( $serialization ) {
+		return $this->getDeserialized( $serialization );
+	}
+
+	/**
+	 * @param array $serialization
+	 *
+	 * @return Term
+	 */
+	private function getDeserialized( $serialization ) {
+		return new LanguageFallbackInfo( $serialization['language'], $serialization['source'] );
+	}
+
+	/**
+	 * @param mixed $serialization
+	 *
+	 * @return boolean
+	 */
+	public function isDeserializerFor( $serialization ) {
+		return isset( $serialization['language'] ) && isset( $serialization['source'] );
+	}
+}

--- a/src/Deserializers/TermDeserializer.php
+++ b/src/Deserializers/TermDeserializer.php
@@ -6,6 +6,7 @@ use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
 use Deserializers\Exceptions\MissingAttributeException;
+use Wikibase\DataModel\Serializers\FacetContainerDeserializer;
 use Wikibase\DataModel\Term\Term;
 
 /**
@@ -15,6 +16,18 @@ use Wikibase\DataModel\Term\Term;
  * @author Adam Shorland
  */
 class TermDeserializer implements Deserializer {
+
+	/**
+	 * @var FacetContainerDeserializer
+	 */
+	private $facetDeserializer;
+
+	/**
+	 * @param FacetContainerDeserializer $facetDeserializer
+	 */
+	public function __construct( FacetContainerDeserializer $facetDeserializer ) {
+		$this->facetDeserializer = $facetDeserializer;
+	}
 
 	/**
 	 * @param mixed $serialization
@@ -33,7 +46,9 @@ class TermDeserializer implements Deserializer {
 	 * @return Term
 	 */
 	private function getDeserialized( $serialization ) {
-		return new Term( $serialization['language'], $serialization['value'] );
+		$term = new Term( $serialization['language'], $serialization['value'] );
+		$this->facetDeserializer->deserializeFacets( $term, $serialization );
+		return $term;
 	}
 
 	/**
@@ -46,8 +61,6 @@ class TermDeserializer implements Deserializer {
 
 		$this->requireAttribute( $serialization, 'language' );
 		$this->requireAttribute( $serialization, 'value' );
-		// Do not deserialize term fallbacks
-		$this->assertNotAttribute( $serialization, 'source' );
 
 		$this->assertAttributeInternalType( $serialization, 'language', 'string' );
 		$this->assertAttributeInternalType( $serialization, 'value', 'string' );
@@ -70,20 +83,6 @@ class TermDeserializer implements Deserializer {
 	private function requireAttribute( $serialization, $attribute ) {
 		if ( !is_array( $serialization ) || !array_key_exists( $attribute, $serialization ) ) {
 			throw new MissingAttributeException( $attribute );
-		}
-	}
-
-	/**
-	 * @param array $array
-	 * @param string $key
-	 */
-	private function assertNotAttribute( array $array, $key ) {
-		if ( array_key_exists( $key, $array ) ) {
-			throw new InvalidAttributeException(
-				$key,
-				$array[$key],
-				'Deserialization of attribute ' . $key . ' not supported.'
-			);
 		}
 	}
 

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -7,7 +7,9 @@ use Serializers\DispatchingSerializer;
 use Serializers\Serializer;
 use Wikibase\DataModel\Serializers\AliasGroupListSerializer;
 use Wikibase\DataModel\Serializers\AliasGroupSerializer;
+use Wikibase\DataModel\Serializers\FacetContainerSerializer;
 use Wikibase\DataModel\Serializers\ItemSerializer;
+use Wikibase\DataModel\Serializers\LanguageFallbackInfoSerializer;
 use Wikibase\DataModel\Serializers\PropertySerializer;
 use Wikibase\DataModel\Serializers\ReferenceListSerializer;
 use Wikibase\DataModel\Serializers\ReferenceSerializer;
@@ -226,7 +228,12 @@ class SerializerFactory {
 	 * @return Serializer
 	 */
 	public function newTermSerializer() {
-		return new TermSerializer();
+		//TODO: get facet serializers from a central registry or hook, so extensions can add their own
+		$facetSerializers = array(
+			'LanguageFallbackInfo' => new LanguageFallbackInfoSerializer(),
+		);
+
+		return new TermSerializer( new FacetContainerSerializer( $facetSerializers ) );
 	}
 
 	/**

--- a/src/Serializers/FacetContainerSerializer.php
+++ b/src/Serializers/FacetContainerSerializer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Wikibase\DataModel\Serializers;
+
+use Serializers\Exceptions\SerializationException;
+use Serializers\Serializer;
+use Wikibase\DataModel\Facet\FacetContainer;
+use Wikimedia\Assert\Assert;
+
+/**
+ * Package private
+ *
+ * @since 2.1
+ *
+ * @licence GNU GPL v2+
+ * @author Daniel Kinzler
+ */
+class FacetContainerSerializer  {
+
+	/**
+	 * @var Serializer[] by facet name
+	 */
+	private $serializers;
+
+	/**
+	 * @param Serializer[] $serializers
+	 */
+	public function __construct( array $serializers ) {
+		Assert::parameterElementType( 'Serializers\Serializer', $serializers, '$serializers' );
+
+		$this->serializers = $serializers;
+	}
+
+	private function getSupportedFacettes() {
+		return array_keys( $this->serializers );
+	}
+
+	/**
+	 * @param object $object The object to serialize.
+	 * @param array &$target The array to merge the facet serializations into
+	 */
+	public function addFacetSerialization( $object, array &$target ) {
+		if ( !( $object instanceof FacetContainer ) ) {
+			return;
+		}
+
+		$names = array_intersect_key( $object->listFacets(), $this->getSupportedFacettes() );
+		foreach ( $names as $name ) {
+			$facet = $object->getFacet( $name );
+			$serializer = $this->serializers[$name];
+
+			$data = $serializer->serialize( $facet );
+			$this->mergeData( $data, $target );
+		}
+	}
+
+	/**
+	 * @param array $data
+	 * @param array &$target
+	 */
+	private function mergeData( array $data, array &$target ) {
+		foreach ( $data as $key => $value ) {
+			if ( array_key_exists( $key, $target ) ) {
+				throw new SerializationException( 'Conflicting facet serializations: key ' . $key . ' is already set.' );
+			}
+
+			$target[$key] = $value;
+		}
+	}
+}

--- a/src/Serializers/LanguageFallbackInfoSerializer.php
+++ b/src/Serializers/LanguageFallbackInfoSerializer.php
@@ -5,26 +5,18 @@ namespace Wikibase\DataModel\Serializers;
 use Serializers\Exceptions\UnsupportedObjectException;
 use Serializers\Serializer;
 use Wikibase\DataModel\Term\Term;
+use Wikibase\DataModel\Term\LanguageFallbackInfo;
 
 /**
  * Package private
  *
+ * @since 2.1
+ *
  * @licence GNU GPL v2+
  * @author Adam Shorland
+ * @author Daniel Kinzler
  */
-class TermSerializer implements Serializer {
-
-	/**
-	 * @var FacetContainerSerializer
-	 */
-	private $facetSerializer;
-
-	/**
-	 * @param FacetContainerSerializer $facetDeserializer
-	 */
-	public function __construct( FacetContainerSerializer $facetSerializer ) {
-		$this->facetSerializer = $facetSerializer;
-	}
+class LanguageFallbackInfoSerializer implements Serializer {
 
 	/**
 	 * @param Term $object
@@ -37,10 +29,10 @@ class TermSerializer implements Serializer {
 	}
 
 	private function assertIsSerializerFor( $object ) {
-		if ( !( $object instanceof Term ) ) {
+		if ( !( $object instanceof LanguageFallbackInfo ) ) {
 			throw new UnsupportedObjectException(
 				$object,
-				'TermSerializer can only serialize Term objects'
+				'LanguageFallbackInfoSerializer can only serialize LanguageFallbackInfo objects'
 			);
 		}
 	}
@@ -50,13 +42,13 @@ class TermSerializer implements Serializer {
 	 *
 	 * @return array
 	 */
-	private function getSerialized( Term $term ) {
-		$result = array(
-			'language' => $term->getLanguageCode(),
-			'value' => $term->getText(),
-		);
+	private function getSerialized( LanguageFallbackInfo $term ) {
+		$result = array();
 
-		$this->facetSerializer->addFacetSerialization( $term, $result );
+		//FIXME: LanguageFallbackInfo probably doesn't need getActualLanguageCode() at all.
+		//$result['language'] = $term->getActualLanguageCode();
+		$result['source'] = $term->getSourceLanguageCode();
+
 		return $result;
 	}
 

--- a/tests/unit/Deserializers/TermDeserializerTest.php
+++ b/tests/unit/Deserializers/TermDeserializerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wikibase\DataModel\Deserializers;
 
 use Deserializers\Deserializer;
 use Wikibase\DataModel\Deserializers\TermDeserializer;
+use Wikibase\DataModel\Serializers\FacetContainerSerializer;
 use Wikibase\DataModel\Term\Term;
 
 /**
@@ -18,7 +19,7 @@ class TermDeserializerTest extends DeserializerBaseTest {
 	 * @return Deserializer
 	 */
 	public function buildDeserializer() {
-		return new TermDeserializer();
+		return new TermDeserializer( new FacetContainerSerializer( array() ) );
 	}
 
 	/**
@@ -34,6 +35,7 @@ class TermDeserializerTest extends DeserializerBaseTest {
 				'language' => 'en-gb',
 				'value' => 'Kittens, Kittens and Unicorns',
 			),
+			//TODO: test facets
 		);
 	}
 
@@ -49,11 +51,6 @@ class TermDeserializerTest extends DeserializerBaseTest {
 			array(
 				'language' => 'de',
 				'value' => 999,
-			),
-			array(
-				'language' => 'fr',
-				'value' => 'Fr to DE hehe',
-				'source' => 'de',
 			),
 		);
 	}

--- a/tests/unit/Serializers/TermSerializerTest.php
+++ b/tests/unit/Serializers/TermSerializerTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Wikibase\DataModel\Serializers;
 
+use Wikibase\DataModel\Serializers\FacetContainerSerializer;
 use Wikibase\DataModel\Serializers\TermSerializer;
 use Wikibase\DataModel\Term\Term;
-use Wikibase\DataModel\Term\TermFallback;
 
 /**
  * @covers Wikibase\DataModel\Serializers\TermSerializer
@@ -18,7 +18,7 @@ class TermSerializerTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider serializationProvider
 	 */
 	public function testSerialization( Term $input, array $expected ) {
-		$serializer = new TermSerializer();
+		$serializer = new TermSerializer( new FacetContainerSerializer( array() ) );
 
 		$output = $serializer->serialize( $input );
 
@@ -26,6 +26,7 @@ class TermSerializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function serializationProvider() {
+		//TODO: test facets
 		return array(
 			array(
 				new Term ( 'en', 'SomeValue' ),
@@ -34,19 +35,11 @@ class TermSerializerTest extends \PHPUnit_Framework_TestCase {
 					'value' => 'SomeValue',
 				)
 			),
-			array(
-				new TermFallback( 'en', 'SomeValue', 'en-gb', 'en' ),
-				array(
-					'language' => 'en-gb',
-					'value' => 'SomeValue',
-					'source' => 'en',
-				)
-			),
 		);
 	}
 
 	public function testWithUnsupportedObject() {
-		$serializer = new TermSerializer();
+		$serializer = new TermSerializer( new FacetContainerSerializer( array() ) );
 		$this->setExpectedException( 'Serializers\Exceptions\UnsupportedObjectException' );
 		$serializer->serialize( new \stdClass() );
 	}


### PR DESCRIPTION
Adds facet (de)serialization infrastructure, and support for the
LanguageFallbackInfo facet for Term.

NOTE: needs unreleased version 5 of wikibase/data-model,
see https://github.com/wmde/WikibaseDataModel/pull/576

NOTE: missing tests for new functionality & classes
