### PR TITLE
Cleaner autoload code in test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,8 +11,11 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-$loader = require_once( __DIR__ . '/../vendor/autoload.php' );
-$loader->addClassMap( array(
+$classLoader = require __DIR__ . '/../vendor/autoload.php';
+
+$classLoader->addClassMap( array(
 	'Tests\Wikibase\DataModel\Serializers\SerializerBaseTest' => __DIR__ . '/unit/Serializers/SerializerBaseTest.php',
 	'Tests\Wikibase\DataModel\Deserializers\DeserializerBaseTest' => __DIR__ . '/unit/Deserializers/DeserializerBaseTest.php'
 ) );
+
+unset( $classLoader );


### PR DESCRIPTION
This fixes a series of minor issues:
* The var contains a `ClassLoader` object. I find it helpful when the name reflects that.
* Not sure what the var contains when the file is not included because of the `_once`. Better be strict and use `require`.
* `require` is not a function, MediaWiki's and Wikibase' PHPCS complain about the brackets.
* `unset` in the end.

Most of this is already done in most bootstrap.php files we have.