### PR TITLE
Fix and add missing types and type hints

### DIFF
--- a/src/Deserializers/AliasGroupListDeserializer.php
+++ b/src/Deserializers/AliasGroupListDeserializer.php
@@ -21,7 +21,7 @@ class AliasGroupListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param mixed $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return AliasGroupList
@@ -32,11 +32,11 @@ class AliasGroupListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @return AliasGroupList
 	 */
-	private function getDeserialized( $serialization ) {
+	private function getDeserialized( array $serialization ) {
 		$aliasGroupList = new AliasGroupList();
 
 		foreach ( $serialization as $languageCode => $aliasGroupSerialization ) {
@@ -66,7 +66,9 @@ class AliasGroupListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param mixed $serialization
+	 *
+	 * @throws DeserializationException
 	 */
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) ) {

--- a/src/Deserializers/TermDeserializer.php
+++ b/src/Deserializers/TermDeserializer.php
@@ -28,16 +28,18 @@ class TermDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param string[] $serialization
 	 *
 	 * @return Term
 	 */
-	private function getDeserialized( $serialization ) {
+	private function getDeserialized( array $serialization ) {
 		return new Term( $serialization['language'], $serialization['value'] );
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param mixed $serialization
+	 *
+	 * @throws DeserializationException
 	 */
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) ) {
@@ -66,6 +68,8 @@ class TermDeserializer implements Deserializer {
 	/**
 	 * @param array $serialization
 	 * @param string $attribute
+	 *
+	 * @throws MissingAttributeException
 	 */
 	private function requireAttribute( $serialization, $attribute ) {
 		if ( !is_array( $serialization ) || !array_key_exists( $attribute, $serialization ) ) {
@@ -76,6 +80,8 @@ class TermDeserializer implements Deserializer {
 	/**
 	 * @param array $array
 	 * @param string $key
+	 *
+	 * @throws InvalidAttributeException
 	 */
 	private function assertNotAttribute( array $array, $key ) {
 		if ( array_key_exists( $key, $array ) ) {

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -31,7 +31,7 @@ class TermListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param mixed $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return TermList
@@ -42,11 +42,11 @@ class TermListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @return TermList
 	 */
-	private function getDeserialized( $serialization ) {
+	private function getDeserialized( array $serialization ) {
 		$termList = new TermList();
 
 		foreach ( $serialization as $termSerialization ) {
@@ -57,7 +57,9 @@ class TermListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param mixed $serialization
+	 *
+	 * @throws DeserializationException
 	 */
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) ) {


### PR DESCRIPTION
I hope most details in this patch are obvious and self-explaining. If not, please ask.

~~The detail you may wonder about is why I'm replacing some "array" with "mixed". Look at the Deserializer interface. Both the interface and this implementation can, technically, called with everything. The assertions make sure the provided serialization is valid. These assertions check way more than the "array" type. Adding "array" as a type hint does not help much. It's probably more confusing than helpful.~~