### PR TITLE
More specific type hints in deserializers

### DIFF
--- a/src/Deserializers/AliasGroupListDeserializer.php
+++ b/src/Deserializers/AliasGroupListDeserializer.php
@@ -21,7 +21,7 @@ class AliasGroupListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return AliasGroupList
@@ -32,11 +32,11 @@ class AliasGroupListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @return AliasGroupList
 	 */
-	private function getDeserialized( $serialization ) {
+	private function getDeserialized( array $serialization ) {
 		$aliasGroupList = new AliasGroupList();
 
 		foreach ( $serialization as $languageCode => $aliasGroupSerialization ) {
@@ -66,7 +66,7 @@ class AliasGroupListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 */

--- a/src/Deserializers/EntityIdDeserializer.php
+++ b/src/Deserializers/EntityIdDeserializer.php
@@ -47,7 +47,7 @@ class EntityIdDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param mixed $serialization
+	 * @param string $serialization
 	 *
 	 * @throws DeserializationException
 	 */

--- a/src/Deserializers/ReferenceListDeserializer.php
+++ b/src/Deserializers/ReferenceListDeserializer.php
@@ -29,7 +29,7 @@ class ReferenceListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return ReferenceList
@@ -41,7 +41,7 @@ class ReferenceListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @return ReferenceList
 	 */

--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -30,7 +30,7 @@ class SnakListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return SnakList
@@ -63,7 +63,7 @@ class SnakListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param mixed $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 */

--- a/src/Deserializers/StatementListDeserializer.php
+++ b/src/Deserializers/StatementListDeserializer.php
@@ -30,7 +30,7 @@ class StatementListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return StatementList

--- a/src/Deserializers/TermDeserializer.php
+++ b/src/Deserializers/TermDeserializer.php
@@ -17,7 +17,7 @@ use Wikibase\DataModel\Term\Term;
 class TermDeserializer implements Deserializer {
 
 	/**
-	 * @param mixed $serialization
+	 * @param string[] $serialization
 	 *
 	 * @return Term
 	 * @throws DeserializationException
@@ -28,16 +28,18 @@ class TermDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param string[] $serialization
 	 *
 	 * @return Term
 	 */
-	private function getDeserialized( $serialization ) {
+	private function getDeserialized( array $serialization ) {
 		return new Term( $serialization['language'], $serialization['value'] );
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param string[] $serialization
+	 *
+	 * @throws DeserializationException
 	 */
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) ) {
@@ -49,23 +51,25 @@ class TermDeserializer implements Deserializer {
 		// Do not deserialize term fallbacks
 		$this->assertNotAttribute( $serialization, 'source' );
 
-		$this->assertAttributeInternalType( $serialization, 'language', 'string' );
-		$this->assertAttributeInternalType( $serialization, 'value', 'string' );
+		$this->assertAttributeIsString( $serialization, 'language' );
+		$this->assertAttributeIsString( $serialization, 'value' );
 	}
 
-	private function assertAttributeInternalType( array $array, $attributeName, $internalType ) {
-		if ( gettype( $array[$attributeName] ) !== $internalType ) {
+	private function assertAttributeIsString( array $array, $attributeName ) {
+		if ( !is_string( $array[$attributeName] ) ) {
 			throw new InvalidAttributeException(
 				$attributeName,
 				$array[$attributeName],
-				"The internal type of attribute '$attributeName' needs to be '$internalType'"
+				"The internal type of attribute '$attributeName' needs to be 'string'"
 			);
 		}
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param string[] $serialization
 	 * @param string $attribute
+	 *
+	 * @throws MissingAttributeException
 	 */
 	private function requireAttribute( $serialization, $attribute ) {
 		if ( !is_array( $serialization ) || !array_key_exists( $attribute, $serialization ) ) {
@@ -74,8 +78,10 @@ class TermDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $array
+	 * @param string[] $array
 	 * @param string $key
+	 *
+	 * @throws InvalidAttributeException
 	 */
 	private function assertNotAttribute( array $array, $key ) {
 		if ( array_key_exists( $key, $array ) ) {

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -31,7 +31,7 @@ class TermListDeserializer implements Deserializer {
 	/**
 	 * @see Deserializer::deserialize
 	 *
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 * @return TermList
@@ -42,11 +42,11 @@ class TermListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @return TermList
 	 */
-	private function getDeserialized( $serialization ) {
+	private function getDeserialized( array $serialization ) {
 		$termList = new TermList();
 
 		foreach ( $serialization as $termSerialization ) {
@@ -57,7 +57,7 @@ class TermListDeserializer implements Deserializer {
 	}
 
 	/**
-	 * @param array $serialization
+	 * @param array[] $serialization
 	 *
 	 * @throws DeserializationException
 	 */
@@ -86,15 +86,11 @@ class TermListDeserializer implements Deserializer {
 	}
 
 	private function assertAttributeIsArray( array $array, $attributeName ) {
-		$this->assertAttributeInternalType( $array, $attributeName, 'array' );
-	}
-
-	private function assertAttributeInternalType( array $array, $attributeName, $internalType ) {
-		if ( gettype( $array[$attributeName] ) !== $internalType ) {
+		if ( !is_array( $array[$attributeName] ) ) {
 			throw new InvalidAttributeException(
 				$attributeName,
 				$array[$attributeName],
-				"The internal type of attribute '$attributeName' needs to be '$internalType'"
+				"The internal type of attribute '$attributeName' needs to be 'array'"
 			);
 		}
 	}

--- a/src/Serializers/AliasGroupListSerializer.php
+++ b/src/Serializers/AliasGroupListSerializer.php
@@ -37,7 +37,7 @@ class AliasGroupListSerializer implements Serializer {
 	/**
 	 * @param AliasGroupList $object
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function serialize( $object ) {
 		$this->assertIsSerializerFor( $object );
@@ -56,7 +56,7 @@ class AliasGroupListSerializer implements Serializer {
 	/**
 	 * @param AliasGroupList $aliasGroupList
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	private function getSerialized( AliasGroupList $aliasGroupList ) {
 		$serialization = array();

--- a/src/Serializers/AliasGroupSerializer.php
+++ b/src/Serializers/AliasGroupSerializer.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Wikibase\DataModel\Serializers;
+
 use Serializers\Exceptions\UnsupportedObjectException;
 use Serializers\Serializer;
 use Wikibase\DataModel\Term\AliasGroup;
@@ -14,11 +15,10 @@ use Wikibase\DataModel\Term\AliasGroupFallback;
  */
 class AliasGroupSerializer implements Serializer {
 
-
 	/**
 	 * @param AliasGroup $object
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function serialize( $object ) {
 		$this->assertIsSerializerFor( $object );
@@ -37,7 +37,7 @@ class AliasGroupSerializer implements Serializer {
 	/**
 	 * @param AliasGroup $aliasGroup
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	private function getSerialized( AliasGroup $aliasGroup ) {
 		$serialization = array();

--- a/src/Serializers/ReferenceListSerializer.php
+++ b/src/Serializers/ReferenceListSerializer.php
@@ -45,7 +45,7 @@ class ReferenceListSerializer implements DispatchableSerializer {
 	 * @param ReferenceList $object
 	 *
 	 * @throws SerializationException
-	 * @return array
+	 * @return array[]
 	 */
 	public function serialize( $object ) {
 		if ( !$this->isSerializerFor( $object ) ) {

--- a/src/Serializers/SnakListSerializer.php
+++ b/src/Serializers/SnakListSerializer.php
@@ -53,7 +53,7 @@ class SnakListSerializer implements DispatchableSerializer {
 	 * @param SnakList $object
 	 *
 	 * @throws SerializationException
-	 * @return array
+	 * @return array[]
 	 */
 	public function serialize( $object ) {
 		if ( !$this->isSerializerFor( $object ) ) {

--- a/src/Serializers/StatementListSerializer.php
+++ b/src/Serializers/StatementListSerializer.php
@@ -52,7 +52,7 @@ class StatementListSerializer implements DispatchableSerializer {
 	 * @param StatementList $object
 	 *
 	 * @throws SerializationException
-	 * @return array
+	 * @return array[]
 	 */
 	public function serialize( $object ) {
 		if ( !$this->isSerializerFor( $object ) ) {

--- a/src/Serializers/TermListSerializer.php
+++ b/src/Serializers/TermListSerializer.php
@@ -39,7 +39,7 @@ class TermListSerializer implements Serializer {
 	 *
 	 * @param TermList $object
 	 *
-	 * @return array
+	 * @return array[]
 	 * @throws SerializationException
 	 */
 	public function serialize( $object ) {
@@ -59,7 +59,7 @@ class TermListSerializer implements Serializer {
 	/**
 	 * @param TermList $termList
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	private function getSerialized( TermList $termList ) {
 		$serialization = array();

--- a/src/Serializers/TermSerializer.php
+++ b/src/Serializers/TermSerializer.php
@@ -18,7 +18,7 @@ class TermSerializer implements Serializer {
 	/**
 	 * @param Term $object
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function serialize( $object ) {
 		$this->assertIsSerializerFor( $object );
@@ -37,7 +37,7 @@ class TermSerializer implements Serializer {
 	/**
 	 * @param Term $term
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	private function getSerialized( Term $term ) {
 		$result = array(


### PR DESCRIPTION
1. This patch adds some missing `@throws` tags. PHPStorm complains about incomplete PHPDoc sections.
2. I'm adding a few "hard" `array` types in cases where a variable is guaranteed to be an array.
3. I'm making all "soft" `@param … $serialization` type hints on `deserialize` functions as specific as they can be. Technically, the Deserializer interface says "mixed". But the implementations will fail with exceptions if the type does not match. You can say: These requirements are part of the interface of these classes and should be documented as such.
4. Same for `@return …` on `serialize`. These methods are guaranteed to return exactly these types, even if the interfaces says "mixed".