### PR TITLE
Compatible with DataValues Common 0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"data-values/serialization": "~1.0"
 	},
 	"require-dev": {
-		"data-values/common": "~0.2",
+		"data-values/common": "~0.3.0|~0.2.0",
 		"data-values/geo": "~1.0|~0.1",
 		"data-values/number": "~0.2",
 		"data-values/time": "~0.2"


### PR DESCRIPTION
* This component is compatible with Common 0.3.x. [The breaking changes between Common 0.2.x and 0.3.x](https://github.com/DataValues/Common/compare/0.2.3...0.3.0) are not used here.

Also see:
* https://github.com/DataValues/Geo/pull/58
* https://github.com/DataValues/Number/pull/53
* https://github.com/wmde/WikibaseInternalSerialization/pull/90