### PR TITLE
Add support for additional entity serializers and deserializers

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.1.0 (dev)
+
+* Added support for additional entity serializers and deserializers
+
 ## 2.0.0 (2015-08-30)
 
 * Dropped dependency on Wikibase DataModel Services

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -42,12 +42,23 @@ class DeserializerFactory {
 	private $entityIdParser;
 
 	/**
+	 * @var DispatchableDeserializer[]
+	 */
+	private $additionalEntityDeserializers;
+
+	/**
 	 * @param Deserializer $dataValueDeserializer deserializer for DataValue objects
 	 * @param EntityIdParser $entityIdParser
+	 * @param DispatchableDeserializer[] $additionalEntityDeserializers
 	 */
-	public function __construct( Deserializer $dataValueDeserializer, EntityIdParser $entityIdParser ) {
+	public function __construct(
+		Deserializer $dataValueDeserializer,
+		EntityIdParser $entityIdParser,
+		array $additionalEntityDeserializers = array()
+	) {
 		$this->dataValueDeserializer = $dataValueDeserializer;
 		$this->entityIdParser = $entityIdParser;
+		$this->additionalEntityDeserializers = $additionalEntityDeserializers;
 	}
 
 	/**
@@ -56,21 +67,40 @@ class DeserializerFactory {
 	 * @return DispatchableDeserializer
 	 */
 	public function newEntityDeserializer() {
-		return new DispatchingDeserializer( array(
-			new ItemDeserializer(
-				$this->newEntityIdDeserializer(),
-				$this->newTermListDeserializer(),
-				$this->newAliasGroupListDeserializer(),
-				$this->newStatementListDeserializer(),
-				$this->newSiteLinkDeserializer()
-			),
-			new PropertyDeserializer(
-				$this->newEntityIdDeserializer(),
-				$this->newTermListDeserializer(),
-				$this->newAliasGroupListDeserializer(),
-				$this->newStatementListDeserializer()
+		return new DispatchingDeserializer(
+			array_merge(
+				$this->additionalEntityDeserializers,
+				array(
+					$this->newItemDeserializer(),
+					$this->newPropertyDeserializer()
+				)
 			)
-		) );
+		);
+	}
+
+	/**
+	 * @return DispatchableDeserializer
+	 */
+	private function newItemDeserializer() {
+		return new ItemDeserializer(
+			$this->newEntityIdDeserializer(),
+			$this->newTermListDeserializer(),
+			$this->newAliasGroupListDeserializer(),
+			$this->newStatementListDeserializer(),
+			$this->newSiteLinkDeserializer()
+		);
+	}
+
+	/**
+	 * @return DispatchableDeserializer
+	 */
+	private function newPropertyDeserializer() {
+		return new PropertyDeserializer(
+			$this->newEntityIdDeserializer(),
+			$this->newTermListDeserializer(),
+			$this->newAliasGroupListDeserializer(),
+			$this->newStatementListDeserializer()
+		);
 	}
 
 	/**


### PR DESCRIPTION
This patch adds an optional parameter to the factory constructors that
allows to inject additional serializers and deserializers to handle custom
entity types.