### PR TITLE
Add public item/property (de)serializer factory methods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,10 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.1.0 (dev)
+
+* Added `newItemSerializer` and `newPropertySerializer` to `SerializerFactory`
+* Added `newItemDeserializer` and `newPropertyDeserializer` to `DeserializerFactory`
+
 ## 2.0.0 (2015-08-30)
 
 * Dropped dependency on Wikibase DataModel Services

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -57,20 +57,42 @@ class DeserializerFactory {
 	 */
 	public function newEntityDeserializer() {
 		return new DispatchingDeserializer( array(
-			new ItemDeserializer(
-				$this->newEntityIdDeserializer(),
-				$this->newTermListDeserializer(),
-				$this->newAliasGroupListDeserializer(),
-				$this->newStatementListDeserializer(),
-				$this->newSiteLinkDeserializer()
-			),
-			new PropertyDeserializer(
-				$this->newEntityIdDeserializer(),
-				$this->newTermListDeserializer(),
-				$this->newAliasGroupListDeserializer(),
-				$this->newStatementListDeserializer()
-			)
+			$this->newItemDeserializer(),
+			$this->newPropertyDeserializer()
 		) );
+	}
+
+	/**
+	 * Returns a Deserializer that can deserialize Item objects.
+	 *
+	 * @since 2.1
+	 *
+	 * @return Deserializer
+	 */
+	public function newItemDeserializer() {
+		return new ItemDeserializer(
+			$this->newEntityIdDeserializer(),
+			$this->newTermListDeserializer(),
+			$this->newAliasGroupListDeserializer(),
+			$this->newStatementListDeserializer(),
+			$this->newSiteLinkDeserializer()
+		);
+	}
+
+	/**
+	 * Returns a Deserializer that can deserialize Property objects.
+	 *
+	 * @since 2.1
+	 *
+	 * @return Deserializer
+	 */
+	public function newPropertyDeserializer() {
+		return new PropertyDeserializer(
+			$this->newEntityIdDeserializer(),
+			$this->newTermListDeserializer(),
+			$this->newAliasGroupListDeserializer(),
+			$this->newStatementListDeserializer()
+		);
 	}
 
 	/**

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -100,19 +100,41 @@ class SerializerFactory {
 	 */
 	public function newEntitySerializer() {
 		return new DispatchingSerializer( array(
-			new ItemSerializer(
-				$this->newTermListSerializer(),
-				$this->newAliasGroupListSerializer(),
-				$this->newStatementListSerializer(),
-				$this->newSiteLinkSerializer(),
-				$this->shouldUseObjectsForMaps()
-			),
-			new PropertySerializer(
-				$this->newTermListSerializer(),
-				$this->newAliasGroupListSerializer(),
-				$this->newStatementListSerializer()
-			)
+			$this->newItemSerializer(),
+			$this->newPropertySerializer()
 		) );
+	}
+
+	/**
+	 * Returns a Serializer that can serialize Item objects.
+	 *
+	 * @since 2.1
+	 *
+	 * @return Serializer
+	 */
+	public function newItemSerializer() {
+		return new ItemSerializer(
+			$this->newTermListSerializer(),
+			$this->newAliasGroupListSerializer(),
+			$this->newStatementListSerializer(),
+			$this->newSiteLinkSerializer(),
+			$this->shouldUseObjectsForMaps()
+		);
+	}
+
+	/**
+	 * Returns a Serializer that can serialize Property objects.
+	 *
+	 * @since 2.1
+	 *
+	 * @return Serializer
+	 */
+	public function newPropertySerializer() {
+		return new PropertySerializer(
+			$this->newTermListSerializer(),
+			$this->newAliasGroupListSerializer(),
+			$this->newStatementListSerializer()
+		);
 	}
 
 	/**

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -36,6 +36,25 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		) );
 	}
 
+	public function testNewItemDeserializer() {
+		$this->assertDeserializesWithoutException(
+			$this->buildDeserializerFactory()->newItemDeserializer(),
+			array(
+				'type' => 'item'
+			)
+		);
+	}
+
+	public function testNewPropertyDeserializer() {
+		$this->assertDeserializesWithoutException(
+			$this->buildDeserializerFactory()->newPropertyDeserializer(),
+			array(
+				'type' => 'property',
+				'datatype' => 'string'
+			)
+		);
+	}
+
 	public function testNewSiteLinkDeserializer() {
 		$this->assertDeserializesWithoutException(
 			$this->buildDeserializerFactory()->newSiteLinkDeserializer(),

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -47,6 +47,20 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testNewItemSerializer() {
+		$this->assertSerializesWithoutException(
+			$this->buildSerializerFactory()->newItemSerializer(),
+			new Item()
+		);
+	}
+
+	public function testNewPropertySerializer() {
+		$this->assertSerializesWithoutException(
+			$this->buildSerializerFactory()->newPropertySerializer(),
+			Property::newFromType( 'string' )
+		);
+	}
+
 	public function testNewSiteLinkSerializer() {
 		$this->assertSerializesWithoutException(
 			$this->buildSerializerFactory()->newSiteLinkSerializer(),


### PR DESCRIPTION
These methods need to be accessible from outside because we want to create
a Dispatchable(De)Serializer in a place where we know all available entity
types and have access to their serializers. That way we can avoid
unneccessarily nesting dispatching serializers and have a clear place in
our code where that dispatching happends.

Bug: [T126932](https://phabricator.wikimedia.org/T126932)