### PR TITLE
Deprecate newEntity(De)Serializer in factories

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,8 @@
 
 * Added `newItemSerializer` and `newPropertySerializer` to `SerializerFactory`
 * Added `newItemDeserializer` and `newPropertyDeserializer` to `DeserializerFactory`
+* Deprecated `SerializerFactory::newEntitySerializer`
+* Deprecated `DeserializerFactory::newEntityDeserializer`
 
 ## 2.0.0 (2015-08-30)
 

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -53,6 +53,8 @@ class DeserializerFactory {
 	/**
 	 * Returns a Deserializer that can deserialize Entity objects.
 	 *
+	 * @deprecated since 2.1, dispatching should happen when all entity types are known
+	 *
 	 * @return DispatchableDeserializer
 	 */
 	public function newEntityDeserializer() {

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -96,6 +96,8 @@ class SerializerFactory {
 	/**
 	 * Returns a Serializer that can serialize Entity objects.
 	 *
+	 * @deprecated since 2.1, dispatching should happen when all entity types are known
+	 *
 	 * @return Serializer
 	 */
 	public function newEntitySerializer() {


### PR DESCRIPTION
Dispatching of serializers per entity type should be done when all entity
types are known instead of here where we only know of item and property.

One could argue that one can dispatch a Dispatching(De)Serializer but that
is worse both performance wise and in terms of software architecture.

Bug: [T126932](https://phabricator.wikimedia.org/T126932)
