### PR TITLE
Avoid using empty property type in Property::newFromType

### DIFF
--- a/tests/unit/Deserializers/PropertyDeserializerTest.php
+++ b/tests/unit/Deserializers/PropertyDeserializerTest.php
@@ -118,23 +118,23 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			),
 		);
 
-		$property = new Property( new PropertyId( 'P42' ), null, '' );
+		$property = new Property( new PropertyId( 'P42' ), null, 'string' );
 		$provider[] = array(
 			$property,
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'id' => 'P42'
 			)
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getFingerprint()->setLabel( 'en', 'foo' );
 		$provider[] = array(
 			$property,
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'labels' => array(
 					'en' => array(
 						'lang' => 'en',
@@ -144,13 +144,13 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getFingerprint()->setDescription( 'en', 'foo' );
 		$provider[] = array(
 			$property,
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'descriptions' => array(
 					'en' => array(
 						'lang' => 'en',
@@ -160,13 +160,13 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getFingerprint()->setAliasGroup( 'en', array( 'foo', 'bar' ) );
 		$provider[] = array(
 			$property,
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'aliases' => array(
 					'en' => array(
 						'lang' => 'en',
@@ -176,13 +176,13 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			$property,
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(
 					'P42' => array(
 						array(
@@ -198,13 +198,13 @@ class PropertyDeserializerTest extends DeserializerBaseTest {
 			)
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			$property,
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(
 					'P42' => array(
 						array(

--- a/tests/unit/Serializers/ItemSerializerTest.php
+++ b/tests/unit/Serializers/ItemSerializerTest.php
@@ -91,23 +91,15 @@ class ItemSerializerTest extends SerializerBaseTest {
 
 	public function serializableProvider() {
 		return array(
-			array(
-				new Item()
-			),
+			array( new Item() ),
 		);
 	}
 
 	public function nonSerializableProvider() {
 		return array(
-			array(
-				5
-			),
-			array(
-				array()
-			),
-			array(
-				Property::newFromType( '' )
-			),
+			array( 5 ),
+			array( array() ),
+			array( Property::newFromType( 'string' ) ),
 		);
 	}
 

--- a/tests/unit/Serializers/PropertySerializerTest.php
+++ b/tests/unit/Serializers/PropertySerializerTest.php
@@ -114,13 +114,13 @@ class PropertySerializerTest extends SerializerBaseTest {
 			),
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->setId( 42 );
 		$provider[] = array(
 			array(
 				'type' => 'property',
 				'id' => 'P42',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(),
 				'labels' => array(),
 				'descriptions' => array(),
@@ -129,12 +129,12 @@ class PropertySerializerTest extends SerializerBaseTest {
 			$property
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getFingerprint()->setLabel( 'en', 'foo' );
 		$provider[] = array(
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(),
 				'labels' => array(
 					'en' => array(
@@ -148,12 +148,12 @@ class PropertySerializerTest extends SerializerBaseTest {
 			$property
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getFingerprint()->setDescription( 'en', 'foo' );
 		$provider[] = array(
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(),
 				'labels' => array(),
 				'descriptions' => array(
@@ -167,12 +167,12 @@ class PropertySerializerTest extends SerializerBaseTest {
 			$property
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getFingerprint()->setAliasGroup( 'en', array( 'foo', 'bar' ) );
 		$provider[] = array(
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(),
 				'labels' => array(),
 				'descriptions' => array(),
@@ -186,12 +186,12 @@ class PropertySerializerTest extends SerializerBaseTest {
 			$property
 		);
 
-		$property = Property::newFromType( '' );
+		$property = Property::newFromType( 'string' );
 		$property->getStatements()->addNewStatement( new PropertyNoValueSnak( 42 ), null, null, 'test' );
 		$provider[] = array(
 			array(
 				'type' => 'property',
-				'datatype' => '',
+				'datatype' => 'string',
 				'claims' => array(
 					'P42' => array(
 						array(


### PR DESCRIPTION
The fact that a property type can be empty is an edge case that should be avoided when the code doesn't really depend on it.