### PR TITLE
Split function headers longer than 100 characters

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -45,7 +45,10 @@ class DeserializerFactory {
 	 * @param Deserializer $dataValueDeserializer deserializer for DataValue objects
 	 * @param EntityIdParser $entityIdParser
 	 */
-	public function __construct( Deserializer $dataValueDeserializer, EntityIdParser $entityIdParser ) {
+	public function __construct(
+		Deserializer $dataValueDeserializer,
+		EntityIdParser $entityIdParser
+	) {
 		$this->dataValueDeserializer = $dataValueDeserializer;
 		$this->entityIdParser = $entityIdParser;
 	}

--- a/src/Deserializers/AliasGroupListDeserializer.php
+++ b/src/Deserializers/AliasGroupListDeserializer.php
@@ -117,7 +117,10 @@ class AliasGroupListDeserializer implements Deserializer {
 		}
 	}
 
-	private function assertRequestedAndActualLanguageMatch( array $serialization, $requestedLanguage ) {
+	private function assertRequestedAndActualLanguageMatch(
+		array $serialization,
+		$requestedLanguage
+	) {
 		if ( $serialization['language'] !== $requestedLanguage ) {
 			throw new DeserializationException(
 				'Deserialization of a value of the attribute language (actual)'

--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -38,7 +38,10 @@ class SnakDeserializer implements DispatchableDeserializer {
 	 * @param Deserializer $dataValueDeserializer
 	 * @param Deserializer $entityIdDeserializer
 	 */
-	public function __construct( Deserializer $dataValueDeserializer, Deserializer $entityIdDeserializer ) {
+	public function __construct(
+		Deserializer $dataValueDeserializer,
+		Deserializer $entityIdDeserializer
+	) {
 		$this->dataValueDeserializer = $dataValueDeserializer;
 		$this->entityIdDeserializer = $entityIdDeserializer;
 	}

--- a/src/Deserializers/StatementDeserializer.php
+++ b/src/Deserializers/StatementDeserializer.php
@@ -40,7 +40,11 @@ class StatementDeserializer implements DispatchableDeserializer {
 	 */
 	private $referencesDeserializer;
 
-	public function __construct( Deserializer $snakDeserializer, Deserializer $snaksDeserializer, Deserializer $referencesDeserializer ) {
+	public function __construct(
+		Deserializer $snakDeserializer,
+		Deserializer $snaksDeserializer,
+		Deserializer $referencesDeserializer
+	) {
 		$this->snakDeserializer = $snakDeserializer;
 		$this->snaksDeserializer = $snaksDeserializer;
 		$this->referencesDeserializer = $referencesDeserializer;

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -58,6 +58,8 @@ class TermListDeserializer implements Deserializer {
 
 	/**
 	 * @param array $serialization
+	 *
+	 * @throws DeserializationException
 	 */
 	private function assertCanDeserialize( $serialization ) {
 		if ( !is_array( $serialization ) ) {
@@ -70,7 +72,10 @@ class TermListDeserializer implements Deserializer {
 		}
 	}
 
-	private function assertRequestedAndActualLanguageMatch( array $serialization, $requestedLanguage ) {
+	private function assertRequestedAndActualLanguageMatch(
+		array $serialization,
+		$requestedLanguage
+	) {
 		if ( $serialization['language'] !== $requestedLanguage ) {
 			throw new DeserializationException(
 				'Deserialization of a value of the attribute language (actual)'

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -18,7 +18,10 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		return new DeserializerFactory( new DataValueDeserializer(), new BasicEntityIdParser() );
 	}
 
-	private function assertDeserializesWithoutException( Deserializer $deserializer, $serialization ) {
+	private function assertDeserializesWithoutException(
+		Deserializer $deserializer,
+		$serialization
+	) {
 		$deserializer->deserialize( $serialization );
 		$this->assertTrue( true, 'No exception occurred during deserialization' );
 	}


### PR DESCRIPTION
This also adds a missing `@throws` I found while splitting these lines.