### PR TITLE
Release 2.1.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,11 @@
 # Wikibase DataModel Serialization release notes
 
-## 2.1.0 (dev)
+## 2.1.0 (2016-02-16)
 
 * Added `newItemSerializer` and `newPropertySerializer` to `SerializerFactory`
 * Added `newItemDeserializer` and `newPropertyDeserializer` to `DeserializerFactory`
+* Added compatibility with Wikibase DataModel 5.x
+* Added compatibility with DataValues Common 0.3
 
 ## 2.0.0 (2015-08-30)
 

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.0.x-dev"
+			"dev-master": "2.1.x-dev"
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require": {
 		"php": ">=5.3.0",
-		"wikibase/data-model": "~4.2",
+		"wikibase/data-model": "~5.0|~4.2",
 		"serialization/serialization": "~3.1",
 		"data-values/serialization": "~1.0"
 	},

--- a/mediawiki-extension.json
+++ b/mediawiki-extension.json
@@ -6,7 +6,7 @@
 	],
 	"url": "https://github.com/wmde/WikibaseDataModelSerialization",
 	"description": "Serializers and deserializers for the Wikibase DataModel",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"type": "wikibase",
 	"license-name": "GPL-2.0+",
 	"manifest_version": 1


### PR DESCRIPTION
This is so cool. We worked hard on the DataModel 5.0 release, discussing what should be in there, and it took us some time. Look how this turns out now. Stuff is still compatible with both versions! I'm happy. :-)

As with https://github.com/wmde/WikibaseDataModelServices/pull/113, please have a look at the open pull requests before tagging a release.

Would be really, really cool to release this today.