### PR TITLE
Release 2.2.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.2.0 (2016-03-11)
+
+* Added compatibility with Wikibase DataModel 6.x
+
 ## 2.1.0 (2016-02-18)
 
 * Added `newItemSerializer` and `newPropertySerializer` to `SerializerFactory`

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.1.x-dev"
+			"dev-master": "2.2.x-dev"
 		}
 	},
 	"scripts": {

--- a/mediawiki-extension.json
+++ b/mediawiki-extension.json
@@ -6,7 +6,7 @@
 	],
 	"url": "https://github.com/wmde/WikibaseDataModelSerialization",
 	"description": "Serializers and deserializers for the Wikibase DataModel",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"type": "wikibase",
 	"license-name": "GPL-2.0+",
 	"manifest_version": 1

--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -54,7 +54,7 @@ class DeserializerFactory {
 	}
 
 	/**
-	 * Returns a Deserializer that can deserialize Entity objects.
+	 * Returns a Deserializer that can deserialize Item and Property objects.
 	 *
 	 * @return DispatchableDeserializer
 	 */

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -94,7 +94,7 @@ class SerializerFactory {
 	}
 
 	/**
-	 * Returns a Serializer that can serialize Entity objects.
+	 * Returns a Serializer that can serialize Item and Property objects.
 	 *
 	 * @return Serializer
 	 */

--- a/tests/integration/EntityDeserializationCompatibilityTest.php
+++ b/tests/integration/EntityDeserializationCompatibilityTest.php
@@ -52,9 +52,9 @@ class EntityDeserializationCompatibilityTest extends \PHPUnit_Framework_TestCase
 		$entity = $this->deserializer->deserialize( $serialization );
 
 		$this->assertInstanceOf(
-			'Wikibase\DataModel\Entity\Entity',
+			'Wikibase\DataModel\Entity\EntityDocument',
 			$entity,
-			'Deserialization of ' . $fileName . ' should lead to an Entity instance'
+			'Deserialization of ' . $fileName . ' should lead to an EntityDocument instance'
 		);
 	}
 


### PR DESCRIPTION
Pinging @Benestar.

Note that the EntityDeserializationCompatibilityTest is in a "slow" group and excluded by default. Fixed in #196.

[Bug: T128468](https://phabricator.wikimedia.org/T128468)