### PR TITLE
Remove slow tag from EntityDeserializationCompatibilityTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,6 @@ This library comes with a set up PHPUnit tests that cover all non-trivial code. 
 tests using the PHPUnit configuration file found in the root directory.
 
     phpunit
-    
-By default the slow tests are not run. You can run them with
-
-    phpunit --group slow
 
 ## Authors
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
 		"data-values/serialization": "~1.0"
 	},
 	"require-dev": {
-		"data-values/common": "~0.3.0|~0.2.0",
 		"data-values/geo": "~1.0|~0.1",
 		"data-values/number": "~0.2",
 		"data-values/time": "~0.2"
@@ -54,8 +53,7 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit",
-			"phpunit --group slow"
+			"phpunit"
 		],
 		"ci": [
 			"composer test"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,11 +16,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <groups>
-        <exclude>
-            <group>slow</group>
-        </exclude>
-    </groups>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>

--- a/tests/integration/EntityDeserializationCompatibilityTest.php
+++ b/tests/integration/EntityDeserializationCompatibilityTest.php
@@ -11,8 +11,6 @@ use Wikibase\DataModel\DeserializerFactory;
 use Wikibase\DataModel\Entity\BasicEntityIdParser;
 
 /**
- * @group slow
- *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
@@ -27,13 +25,9 @@ class EntityDeserializationCompatibilityTest extends \PHPUnit_Framework_TestCase
 		$deserializerFactory = new DeserializerFactory(
 			new DataValueDeserializer(
 				array(
-					'boolean' => 'DataValues\BooleanValue',
-					'number' => 'DataValues\NumberValue',
 					'string' => 'DataValues\StringValue',
 					'unknown' => 'DataValues\UnknownValue',
 					'globecoordinate' => 'DataValues\GlobeCoordinateValue',
-					'monolingualtext' => 'DataValues\MonolingualTextValue',
-					'multilingualtext' => 'DataValues\MultilingualTextValue',
 					'quantity' => 'DataValues\QuantityValue',
 					'time' => 'DataValues\TimeValue',
 					'wikibase-entityid' => 'Wikibase\DataModel\Entity\EntityIdValue',
@@ -52,7 +46,7 @@ class EntityDeserializationCompatibilityTest extends \PHPUnit_Framework_TestCase
 		$entity = $this->deserializer->deserialize( $serialization );
 
 		$this->assertInstanceOf(
-			'Wikibase\DataModel\Entity\Entity',
+			'Wikibase\DataModel\Entity\EntityDocument',
 			$entity,
 			'Deserialization of ' . $fileName . ' should lead to an Entity instance'
 		);


### PR DESCRIPTION
This test is not so slow that it should be an issue. It's less than a second. Not having this executed by default when you type "phpunit" is a bigger issue, in my opinion.

I'm also removing all value types that do not appear in the data directory.