### PR TITLE
Update DataModel version matrix in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,17 @@ env:
 matrix:
   fast_finish: true
   include:
-    - env: DM=~4.0
+    - env: DM=~6.0
       php: 5.3
     - env: DM=@dev
       php: 5.4
-    - env: DM=~5.0@dev
-      php: 5.6
+    - env: DM=~6.0
+      php: 5.5
     - env: DM=~5.0
+      php: 5.6
+    - env: DM=~4.2
       php: 7
-    - env: DM=~4.0
+    - env: DM=~4.2
       php: hhvm
   exclude:
     - env: THENEEDFORTHIS=FAIL


### PR DESCRIPTION
* PHP 5.6 was not tested.
* ~4.0 is misleading because this is not compatible with versions before 4.2 any more.
* Testing with 5.0@dev is obsolete with 6.0.

Same in:
* https://github.com/wmde/WikibaseDataModelServices/pull/140
* https://github.com/wmde/WikibaseInternalSerialization/pull/108