### PR TITLE
Update DataValues Number to 0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 	},
 	"require-dev": {
 		"data-values/geo": "~1.0|~0.1",
-		"data-values/number": "~0.2",
+		"data-values/number": ">=0.1 <0.9",
 		"data-values/time": "~0.2"
 	},
 	"autoload": {


### PR DESCRIPTION
Note that this is in the `require-dev` section and not critical for anything. The only detail this component cares about is if the QuantityValue class exists or not, which is the case in all versions. This is mostly for consistency and does not need a release.