### PR TITLE
Fix all "incompatible type" warnings

### DIFF
--- a/src/Deserializers/ItemDeserializer.php
+++ b/src/Deserializers/ItemDeserializer.php
@@ -6,7 +6,12 @@ use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\TypedObjectDeserializer;
 use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\SiteLinkList;
+use Wikibase\DataModel\Statement\StatementList;
+use Wikibase\DataModel\Term\AliasGroupList;
+use Wikibase\DataModel\Term\TermList;
 
 /**
  * Package private
@@ -95,29 +100,31 @@ class ItemDeserializer extends TypedObjectDeserializer {
 			return;
 		}
 
-		$item->setId( $this->entityIdDeserializer->deserialize( $serialization['id'] ) );
+		/** @var ItemId $id */
+		$id = $this->entityIdDeserializer->deserialize( $serialization['id'] );
+		$item->setId( $id );
 	}
 
 	private function setTermsFromSerialization( array $serialization, Item $item ) {
 		if ( array_key_exists( 'labels', $serialization ) ) {
 			$this->assertAttributeIsArray( $serialization, 'labels' );
-			$item->getFingerprint()->setLabels(
-				$this->termListDeserializer->deserialize( $serialization['labels'] )
-			);
+			/** @var TermList $labels */
+			$labels = $this->termListDeserializer->deserialize( $serialization['labels'] );
+			$item->getFingerprint()->setLabels( $labels );
 		}
 
 		if ( array_key_exists( 'descriptions', $serialization ) ) {
 			$this->assertAttributeIsArray( $serialization, 'descriptions' );
-			$item->getFingerprint()->setDescriptions(
-				$this->termListDeserializer->deserialize( $serialization['descriptions'] )
-			);
+			/** @var TermList $descriptions */
+			$descriptions = $this->termListDeserializer->deserialize( $serialization['descriptions'] );
+			$item->getFingerprint()->setDescriptions( $descriptions );
 		}
 
 		if ( array_key_exists( 'aliases', $serialization ) ) {
 			$this->assertAttributeIsArray( $serialization, 'aliases' );
-			$item->getFingerprint()->setAliasGroups(
-				$this->aliasGroupListDeserializer->deserialize( $serialization['aliases'] )
-			);
+			/** @var AliasGroupList $aliases */
+			$aliases = $this->aliasGroupListDeserializer->deserialize( $serialization['aliases'] );
+			$item->getFingerprint()->setAliasGroups( $aliases );
 		}
 	}
 
@@ -126,6 +133,7 @@ class ItemDeserializer extends TypedObjectDeserializer {
 			return;
 		}
 
+		/** @var StatementList $statements */
 		$statements = $this->statementListDeserializer->deserialize( $serialization['claims'] );
 		$item->setStatements( $statements );
 	}
@@ -141,9 +149,9 @@ class ItemDeserializer extends TypedObjectDeserializer {
 		$this->assertAttributeIsArray( $serialization, 'sitelinks' );
 
 		foreach ( $serialization['sitelinks'] as $siteLinksSerialization ) {
-			$siteLinkList->addSiteLink(
-				$this->siteLinkDeserializer->deserialize( $siteLinksSerialization )
-			);
+			/** @var SiteLink $siteLink */
+			$siteLink = $this->siteLinkDeserializer->deserialize( $siteLinksSerialization );
+			$siteLinkList->addSiteLink( $siteLink );
 		}
 	}
 

--- a/src/Deserializers/PropertyDeserializer.php
+++ b/src/Deserializers/PropertyDeserializer.php
@@ -6,6 +6,10 @@ use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\TypedObjectDeserializer;
 use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Statement\StatementList;
+use Wikibase\DataModel\Term\AliasGroupList;
+use Wikibase\DataModel\Term\TermList;
 
 /**
  * Package private
@@ -93,29 +97,31 @@ class PropertyDeserializer extends TypedObjectDeserializer {
 			return;
 		}
 
-		$property->setId( $this->entityIdDeserializer->deserialize( $serialization['id'] ) );
+		/** @var PropertyId $id */
+		$id = $this->entityIdDeserializer->deserialize( $serialization['id'] );
+		$property->setId( $id );
 	}
 
 	private function setTermsFromSerialization( array $serialization, Property $property ) {
 		if ( array_key_exists( 'labels', $serialization ) ) {
 			$this->assertAttributeIsArray( $serialization, 'labels' );
-			$property->getFingerprint()->setLabels(
-				$this->termListDeserializer->deserialize( $serialization['labels'] )
-			);
+			/** @var TermList $labels */
+			$labels = $this->termListDeserializer->deserialize( $serialization['labels'] );
+			$property->getFingerprint()->setLabels( $labels );
 		}
 
 		if ( array_key_exists( 'descriptions', $serialization ) ) {
 			$this->assertAttributeIsArray( $serialization, 'descriptions' );
-			$property->getFingerprint()->setDescriptions(
-				$this->termListDeserializer->deserialize( $serialization['descriptions'] )
-			);
+			/** @var TermList $descriptions */
+			$descriptions = $this->termListDeserializer->deserialize( $serialization['descriptions'] );
+			$property->getFingerprint()->setDescriptions( $descriptions );
 		}
 
 		if ( array_key_exists( 'aliases', $serialization ) ) {
 			$this->assertAttributeIsArray( $serialization, 'aliases' );
-			$property->getFingerprint()->setAliasGroups(
-				$this->aliasGroupListDeserializer->deserialize( $serialization['aliases'] )
-			);
+			/** @var AliasGroupList $aliases */
+			$aliases = $this->aliasGroupListDeserializer->deserialize( $serialization['aliases'] );
+			$property->getFingerprint()->setAliasGroups( $aliases );
 		}
 	}
 
@@ -124,6 +130,7 @@ class PropertyDeserializer extends TypedObjectDeserializer {
 			return;
 		}
 
+		/** @var StatementList $statements */
 		$statements = $this->statementListDeserializer->deserialize( $serialization['claims'] );
 		$property->setStatements( $statements );
 	}

--- a/src/Deserializers/ReferenceListDeserializer.php
+++ b/src/Deserializers/ReferenceListDeserializer.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Deserializers;
 
 use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
+use Wikibase\DataModel\Reference;
 use Wikibase\DataModel\ReferenceList;
 
 /**
@@ -49,7 +50,9 @@ class ReferenceListDeserializer implements Deserializer {
 		$referenceList = new ReferenceList();
 
 		foreach ( $serialization as $referenceSerialization ) {
-			$referenceList->addReference( $this->referenceDeserializer->deserialize( $referenceSerialization ) );
+			/** @var Reference $reference */
+			$reference = $this->referenceDeserializer->deserialize( $referenceSerialization );
+			$referenceList->addReference( $reference );
 		}
 
 		return $referenceList;

--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -127,6 +127,12 @@ class SnakDeserializer implements DispatchableDeserializer {
 		}
 	}
 
+	/**
+	 * @param string $serialization
+	 *
+	 * @throw InvalidAttributeException
+	 * @return PropertyId
+	 */
 	private function deserializePropertyId( $serialization ) {
 		$propertyId = $this->entityIdDeserializer->deserialize( $serialization );
 

--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Deserializers;
 
 use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
+use Wikibase\DataModel\Snak\Snak;
 use Wikibase\DataModel\Snak\SnakList;
 
 /**
@@ -52,10 +53,14 @@ class SnakListDeserializer implements Deserializer {
 		foreach ( $serialization as $key => $snakArray ) {
 			if ( is_string( $key ) ) {
 				foreach ( $snakArray as $snakSerialization ) {
-					$snakList->addElement( $this->snakDeserializer->deserialize( $snakSerialization ) );
+					/** @var Snak $snak */
+					$snak = $this->snakDeserializer->deserialize( $snakSerialization );
+					$snakList->addElement( $snak );
 				}
 			} else {
-				$snakList->addElement( $this->snakDeserializer->deserialize( $snakArray ) );
+				/** @var Snak $snak */
+				$snak = $this->snakDeserializer->deserialize( $snakArray );
+				$snakList->addElement( $snak );
 			}
 		}
 

--- a/src/Deserializers/StatementDeserializer.php
+++ b/src/Deserializers/StatementDeserializer.php
@@ -9,6 +9,9 @@ use Deserializers\Exceptions\InvalidAttributeException;
 use Deserializers\Exceptions\MissingAttributeException;
 use Deserializers\Exceptions\MissingTypeException;
 use Deserializers\Exceptions\UnsupportedTypeException;
+use Wikibase\DataModel\ReferenceList;
+use Wikibase\DataModel\Snak\Snak;
+use Wikibase\DataModel\Snak\SnakList;
 use Wikibase\DataModel\Statement\Statement;
 
 /**
@@ -90,8 +93,8 @@ class StatementDeserializer implements DispatchableDeserializer {
 	 * @return Statement
 	 */
 	private function getDeserialized( array $serialization ) {
+		/** @var Snak $mainSnak */
 		$mainSnak = $this->snakDeserializer->deserialize( $serialization['mainsnak'] );
-
 		$statement = new Statement( $mainSnak );
 
 		$this->setGuidFromSerialization( $serialization, $statement );
@@ -119,6 +122,7 @@ class StatementDeserializer implements DispatchableDeserializer {
 			return;
 		}
 
+		/** @var SnakList $qualifiers */
 		$qualifiers = $this->snaksDeserializer->deserialize( $serialization['qualifiers'] );
 
 		if ( array_key_exists( 'qualifiers-order', $serialization ) ) {
@@ -147,7 +151,9 @@ class StatementDeserializer implements DispatchableDeserializer {
 			return;
 		}
 
-		$statement->setReferences( $this->referencesDeserializer->deserialize( $serialization['references'] ) );
+		/** @var ReferenceList $references */
+		$references = $this->referencesDeserializer->deserialize( $serialization['references'] );
+		$statement->setReferences( $references );
 	}
 
 	private function assertCanDeserialize( $serialization ) {

--- a/src/Deserializers/StatementListDeserializer.php
+++ b/src/Deserializers/StatementListDeserializer.php
@@ -4,6 +4,7 @@ namespace Wikibase\DataModel\Deserializers;
 
 use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
+use Wikibase\DataModel\Statement\Statement;
 use Wikibase\DataModel\Statement\StatementList;
 
 /**
@@ -52,12 +53,14 @@ class StatementListDeserializer implements Deserializer {
 		foreach ( $serialization as $key => $statementArray ) {
 			if ( is_string( $key ) ) {
 				foreach ( $statementArray as $statementSerialization ) {
-					$statementList->addStatement(
-						$this->statementDeserializer->deserialize( $statementSerialization )
-					);
+					/** @var Statement $statement */
+					$statement = $this->statementDeserializer->deserialize( $statementSerialization );
+					$statementList->addStatement( $statement );
 				}
 			} else {
-				$statementList->addStatement( $this->statementDeserializer->deserialize( $statementArray ) );
+				/** @var Statement $statement */
+				$statement = $this->statementDeserializer->deserialize( $statementArray );
+				$statementList->addStatement( $statement );
 			}
 
 		}

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -5,6 +5,7 @@ namespace Wikibase\DataModel\Deserializers;
 use Deserializers\Deserializer;
 use Deserializers\Exceptions\DeserializationException;
 use Deserializers\Exceptions\InvalidAttributeException;
+use Wikibase\DataModel\Term\Term;
 use Wikibase\DataModel\Term\TermList;
 
 /**
@@ -50,7 +51,9 @@ class TermListDeserializer implements Deserializer {
 		$termList = new TermList();
 
 		foreach ( $serialization as $termSerialization ) {
-			$termList->setTerm( $this->termDeserializer->deserialize( $termSerialization ) );
+			/** @var Term $term */
+			$term = $this->termDeserializer->deserialize( $termSerialization );
+			$termList->setTerm( $term );
 		}
 
 		return $termList;


### PR DESCRIPTION
This patch fixes a lot of type safety warnings in this code without touching any interface or exposing package private knowledge.

This is an addition to #198. It does not make #198 obsolete.