### PR TITLE
Merge duplicate array loops

### DIFF
--- a/src/Deserializers/AliasGroupListDeserializer.php
+++ b/src/Deserializers/AliasGroupListDeserializer.php
@@ -27,7 +27,10 @@ class AliasGroupListDeserializer implements Deserializer {
 	 * @return AliasGroupList
 	 */
 	public function deserialize( $serialization ) {
-		$this->assertCanDeserialize( $serialization );
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'The aliasGroup list serialization should be an array' );
+		}
+
 		return $this->getDeserialized( $serialization );
 	}
 
@@ -40,6 +43,8 @@ class AliasGroupListDeserializer implements Deserializer {
 		$aliasGroupList = new AliasGroupList();
 
 		foreach ( $serialization as $languageCode => $aliasGroupSerialization ) {
+			$this->assertAttributeIsArray( $serialization, $languageCode );
+
 			$aliasGroupList->setGroup( $this->deserializeAliasGroup( $aliasGroupSerialization, $languageCode ) );
 		}
 
@@ -56,6 +61,8 @@ class AliasGroupListDeserializer implements Deserializer {
 		$aliases = array();
 
 		foreach ( $serialization as $aliasSerialization ) {
+			$this->assertIsValidAliasSerialization( $aliasSerialization, $languageCode );
+
 			$aliases[] = $aliasSerialization['value'];
 		}
 
@@ -63,25 +70,6 @@ class AliasGroupListDeserializer implements Deserializer {
 			$languageCode,
 			$aliases
 		);
-	}
-
-	/**
-	 * @param array[] $serialization
-	 *
-	 * @throws DeserializationException
-	 */
-	private function assertCanDeserialize( $serialization ) {
-		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'The aliasGroup list serialization should be an array' );
-		}
-
-		foreach ( $serialization as $requestedLanguage => $valueSerialization ) {
-			$this->assertAttributeIsArray( $serialization, $requestedLanguage );
-
-			foreach ( $valueSerialization as $aliasSerialization ) {
-				$this->assertIsValidAliasSerialization( $aliasSerialization, $requestedLanguage );
-			}
-		}
 	}
 
 	private function assertIsValidAliasSerialization( $serialization, $requestedLanguage ) {

--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -37,7 +37,9 @@ class SnakListDeserializer implements Deserializer {
 	 * @return SnakList
 	 */
 	public function deserialize( $serialization ) {
-		$this->assertHasGoodFormat( $serialization );
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'The SnakList serialization should be an array' );
+		}
 
 		return $this->getDeserialized( $serialization );
 	}
@@ -52,6 +54,10 @@ class SnakListDeserializer implements Deserializer {
 
 		foreach ( $serialization as $key => $snakArray ) {
 			if ( is_string( $key ) ) {
+				if ( !is_array( $snakArray ) ) {
+					throw new DeserializationException( "The snaks per property \"$key\" should be an array" );
+				}
+
 				foreach ( $snakArray as $snakSerialization ) {
 					/** @var Snak $snak */
 					$snak = $this->snakDeserializer->deserialize( $snakSerialization );
@@ -65,23 +71,6 @@ class SnakListDeserializer implements Deserializer {
 		}
 
 		return $snakList;
-	}
-
-	/**
-	 * @param array[] $serialization
-	 *
-	 * @throws DeserializationException
-	 */
-	private function assertHasGoodFormat( $serialization ) {
-		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'The SnakList serialization should be an array' );
-		}
-
-		foreach ( $serialization as $key => $snakArray ) {
-			if ( is_string( $key ) && !is_array( $snakArray ) ) {
-				throw new DeserializationException( 'The snaks per property should be an array' );
-			}
-		}
 	}
 
 }

--- a/src/Deserializers/StatementListDeserializer.php
+++ b/src/Deserializers/StatementListDeserializer.php
@@ -37,7 +37,9 @@ class StatementListDeserializer implements Deserializer {
 	 * @return StatementList
 	 */
 	public function deserialize( $serialization ) {
-		$this->assertHasGoodFormat( $serialization );
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'The StatementList serialization should be an array' );
+		}
 
 		return $this->getDeserialized( $serialization );
 	}
@@ -52,6 +54,10 @@ class StatementListDeserializer implements Deserializer {
 
 		foreach ( $serialization as $key => $statementArray ) {
 			if ( is_string( $key ) ) {
+				if ( !is_array( $statementArray ) ) {
+					throw new DeserializationException( "The statements per property \"$key\" should be an array" );
+				}
+
 				foreach ( $statementArray as $statementSerialization ) {
 					/** @var Statement $statement */
 					$statement = $this->statementDeserializer->deserialize( $statementSerialization );
@@ -62,22 +68,9 @@ class StatementListDeserializer implements Deserializer {
 				$statement = $this->statementDeserializer->deserialize( $statementArray );
 				$statementList->addStatement( $statement );
 			}
-
 		}
 
 		return $statementList;
-	}
-
-	private function assertHasGoodFormat( $serialization ) {
-		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'The StatementList serialization should be an array' );
-		}
-
-		foreach ( $serialization as $key => $statementArray ) {
-			if ( is_string( $key ) && !is_array( $statementArray ) ) {
-				throw new DeserializationException( 'The statements per property should be an array' );
-			}
-		}
 	}
 
 }

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -38,7 +38,10 @@ class TermListDeserializer implements Deserializer {
 	 * @return TermList
 	 */
 	public function deserialize( $serialization ) {
-		$this->assertCanDeserialize( $serialization );
+		if ( !is_array( $serialization ) ) {
+			throw new DeserializationException( 'The term list serialization should be an array' );
+		}
+
 		return $this->getDeserialized( $serialization );
 	}
 
@@ -50,29 +53,16 @@ class TermListDeserializer implements Deserializer {
 	private function getDeserialized( array $serialization ) {
 		$termList = new TermList();
 
-		foreach ( $serialization as $termSerialization ) {
+		foreach ( $serialization as $requestedLanguage => $termSerialization ) {
+			$this->assertAttributeIsArray( $serialization, $requestedLanguage );
+			$this->assertRequestedAndActualLanguageMatch( $termSerialization, $requestedLanguage );
+
 			/** @var Term $term */
 			$term = $this->termDeserializer->deserialize( $termSerialization );
 			$termList->setTerm( $term );
 		}
 
 		return $termList;
-	}
-
-	/**
-	 * @param array[] $serialization
-	 *
-	 * @throws DeserializationException
-	 */
-	private function assertCanDeserialize( $serialization ) {
-		if ( !is_array( $serialization ) ) {
-			throw new DeserializationException( 'The term list serialization should be an array' );
-		}
-
-		foreach ( $serialization as $requestedLanguage => $valueSerialization ) {
-			$this->assertAttributeIsArray( $serialization, $requestedLanguage );
-			$this->assertRequestedAndActualLanguageMatch( $valueSerialization, $requestedLanguage );
-		}
 	}
 
 	private function assertRequestedAndActualLanguageMatch(


### PR DESCRIPTION
This patch does have two effects:
* It merges duplicate loops that looped the exact same arrays twice.
* This allows to avoid a few duplicate condition checks, e.g. duplicate `is_string`.

This is a direct follow up for #205.

[Bug: T157959](https://phabricator.wikimedia.org/T157959)