### PR TITLE
Release 2.3.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.3.0 (2017-02-07)
+
+* Improved performance of `StatementDeserializer`.
+* Improved type safety throughout the code.
+* Reworked `DeserializerBaseTest` into `DispatchableDeserializerTest`.
+* Reworked `SerializerBaseTest` into `DispatchableSerializerTest`.
+
 ## 2.2.0 (2016-03-11)
 
 * Added compatibility with Wikibase DataModel 6.x

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.2.x-dev"
+			"dev-master": "2.3.x-dev"
 		}
 	},
 	"scripts": {

--- a/mediawiki-extension.json
+++ b/mediawiki-extension.json
@@ -6,7 +6,7 @@
 	],
 	"url": "https://github.com/wmde/WikibaseDataModelSerialization",
 	"description": "Serializers and deserializers for the Wikibase DataModel",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"type": "wikibase",
 	"license-name": "GPL-2.0+",
 	"manifest_version": 1


### PR DESCRIPTION
I consider the two removed `DeserializerBaseTest` and `SerializerBaseTest` base classes an implementation detail and not a braking change.