### PR TITLE
[DNM] Make factories support custom entity types

### DIFF
--- a/tests/integration/EntityDeserializationCompatibilityTest.php
+++ b/tests/integration/EntityDeserializationCompatibilityTest.php
@@ -23,6 +23,14 @@ class EntityDeserializationCompatibilityTest extends \PHPUnit_Framework_TestCase
 
 	protected function setUp() {
 		$deserializerFactory = new DeserializerFactory(
+			[
+				function ( DeserializerFactory $factory ) {
+					return $factory->newItemDeserializer();
+				},
+				function ( DeserializerFactory $factory ) {
+					return $factory->newPropertyDeserializer();
+				},
+			],
 			new DataValueDeserializer(
 				array(
 					'string' => 'DataValues\StringValue',

--- a/tests/integration/EntitySerializationRoundtripTest.php
+++ b/tests/integration/EntitySerializationRoundtripTest.php
@@ -23,8 +23,26 @@ class EntitySerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider entityProvider
 	 */
 	public function testEntitySerializationRoundtrips( EntityDocument $entity ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory(
+			[
+				function ( SerializerFactory $factory ) {
+					return $factory->newItemSerializer();
+				},
+				function ( SerializerFactory $factory ) {
+					return $factory->newPropertySerializer();
+				},
+			],
+			new DataValueSerializer()
+		);
 		$deserializerFactory = new DeserializerFactory(
+			[
+				function ( DeserializerFactory $factory ) {
+					return $factory->newItemDeserializer();
+				},
+				function ( DeserializerFactory $factory ) {
+					return $factory->newPropertyDeserializer();
+				},
+			],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/ReferenceSerializationRoundtripTest.php
+++ b/tests/integration/ReferenceSerializationRoundtripTest.php
@@ -23,8 +23,9 @@ class ReferenceSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider referenceProvider
 	 */
 	public function testSnakSerializationRoundtrips( Reference $reference ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory( [], new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/ReferencesSerializationRoundtripTest.php
+++ b/tests/integration/ReferencesSerializationRoundtripTest.php
@@ -22,8 +22,9 @@ class ReferencesSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider referencesProvider
 	 */
 	public function testReferenceSerializationRoundtrips( ReferenceList $references ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory( [], new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/SiteLinkSerializationRoundtripTest.php
+++ b/tests/integration/SiteLinkSerializationRoundtripTest.php
@@ -20,8 +20,9 @@ class SiteLinkSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider siteLinkProvider
 	 */
 	public function testSiteLinkSerializationRoundtrips( SiteLink $siteLink ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory( [], new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/SnakListSerializationRoundtripTest.php
+++ b/tests/integration/SnakListSerializationRoundtripTest.php
@@ -22,8 +22,9 @@ class SnakListSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider snakListProvider
 	 */
 	public function testSnakSerializationRoundtrips( SnakList $snaks ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory( [], new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/SnakSerializationRoundtripTest.php
+++ b/tests/integration/SnakSerializationRoundtripTest.php
@@ -23,12 +23,13 @@ use Wikibase\DataModel\Snak\Snak;
 class SnakSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 
 	private function getSnakSerializer() {
-		$factory = new SerializerFactory( new DataValueSerializer() );
+		$factory = new SerializerFactory( [], new DataValueSerializer() );
 		return $factory->newSnakSerializer();
 	}
 
 	private function getSnakDeserializer( array $dataValueClasses = array() ) {
 		$factory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer( $dataValueClasses ),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/StatementListSerializationRoundtripTest.php
+++ b/tests/integration/StatementListSerializationRoundtripTest.php
@@ -21,8 +21,9 @@ class StatementListSerializationRoundtripTest extends \PHPUnit_Framework_TestCas
 	 * @dataProvider snaksProvider
 	 */
 	public function testSnakSerializationRoundtrips( StatementList $statements ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory( [], new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/integration/StatementSerializationRoundtripTest.php
+++ b/tests/integration/StatementSerializationRoundtripTest.php
@@ -24,8 +24,9 @@ class StatementSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider snaksProvider
 	 */
 	public function testSnakSerializationRoundtrips( Statement $statement ) {
-		$serializerFactory = new SerializerFactory( new DataValueSerializer() );
+		$serializerFactory = new SerializerFactory( [], new DataValueSerializer() );
 		$deserializerFactory = new DeserializerFactory(
+			[],
 			new DataValueDeserializer(),
 			new BasicEntityIdParser()
 		);

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -15,7 +15,14 @@ use Wikibase\DataModel\Entity\BasicEntityIdParser;
 class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	private function buildDeserializerFactory() {
-		return new DeserializerFactory( new DataValueDeserializer(), new BasicEntityIdParser() );
+		return new DeserializerFactory( [
+			function ( DeserializerFactory $factory ) {
+				return $factory->newItemDeserializer();
+			},
+			function ( DeserializerFactory $factory ) {
+				return $factory->newPropertyDeserializer();
+			},
+		], new DataValueDeserializer(), new BasicEntityIdParser() );
 	}
 
 	private function assertDeserializesWithoutException(

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -28,7 +28,14 @@ use Wikibase\DataModel\Term\TermList;
 class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	private function buildSerializerFactory() {
-		return new SerializerFactory( new DataValueSerializer() );
+		return new SerializerFactory( [
+			function ( SerializerFactory $factory ) {
+				return $factory->newItemSerializer();
+			},
+			function ( SerializerFactory $factory ) {
+				return $factory->newPropertySerializer();
+			},
+		], new DataValueSerializer() );
 	}
 
 	private function assertSerializesWithoutException( Serializer $serializer, $object ) {
@@ -113,11 +120,11 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testFactoryCreateWithUnexpectedValue() {
 		$this->setExpectedException( 'InvalidArgumentException' );
-		new SerializerFactory( new DataValueSerializer(), 1.0 );
+		new SerializerFactory( [], new DataValueSerializer(), 1.0 );
 	}
 
 	public function testNewSnakListSerializerWithUseObjectsForMaps() {
-		$factory = new SerializerFactory( new DataValueSerializer(), SerializerFactory::OPTION_OBJECTS_FOR_MAPS );
+		$factory = new SerializerFactory( [], new DataValueSerializer(), SerializerFactory::OPTION_OBJECTS_FOR_MAPS );
 		$serializer = $factory->newSnakListSerializer();
 		$this->assertAttributeSame( true, 'useObjectsForMaps' , $serializer );
 	}


### PR DESCRIPTION
**Do not merge!** I figured this is the wrong approach. See https://gerrit.wikimedia.org/r/338749 instead.

~~This is more than a convenient method, but solves an actual issue. This allows us to construct a SerializerFactory (and pass it around) that is able to serialize more than the basic entity types.~~

Please review this along with https://github.com/wmde/WikibaseInternalSerialization/pull/110. Both changes must be done together, or not. As @JeroenDeDauw hinted below the architecture proposed in these two patches might be flawed. Could it be that we are just confused by these duplicate (De)SerializerFactories? That other component is called "internal". What does this mean? Could it be that the only thing we need to do is to rename these components and classes to make it more obvious what they represent?

[Bug: T157596](https://phabricator.wikimedia.org/T157596)
[Bug: T157960](https://phabricator.wikimedia.org/T157960)