### PR TITLE
Release 2.3.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,8 +1,8 @@
 # Wikibase DataModel Serialization release notes
 
-## 2.3.0 (dev)
+## 2.3.0 (2017-02-13)
 
-* Improved performance of `StatementDeserializer`
+* Improved performance of `StatementDeserializer` as well as other deserializers
 * Improved type safety throughout the code
 * Dropped support for PHP 5.3 and PHP 5.4
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Wikibase DataModel Serialization release notes
 
-## 2.3.0 (2017-02-13)
+## 2.3.0 (2017-02-15)
 
 * Improved performance of `StatementDeserializer` as well as other deserializers
 * Improved type safety throughout the code


### PR DESCRIPTION
I suggest to merge everything in https://github.com/wmde/WikibaseDataModelSerialization/milestone/7 (#206, #207 and #208) and tag an early release 2.3.0.

Then merge #212 and tag a braking 3.0.0 release.

[Bug: T157959](https://phabricator.wikimedia.org/T157959)