### PR TITLE
Do not use SnakList::addElement

### DIFF
--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -61,12 +61,12 @@ class SnakListDeserializer implements Deserializer {
 				foreach ( $snakArray as $snakSerialization ) {
 					/** @var Snak $snak */
 					$snak = $this->snakDeserializer->deserialize( $snakSerialization );
-					$snakList->addElement( $snak );
+					$snakList->addSnak( $snak );
 				}
 			} else {
 				/** @var Snak $snak */
 				$snak = $this->snakDeserializer->deserialize( $snakArray );
-				$snakList->addElement( $snak );
+				$snakList->addSnak( $snak );
 			}
 		}
 


### PR DESCRIPTION
This is quite critical. I believe `addElement` should be considered an implementation detail, because this is the method from the underlying abstract `HashArray` base class. The `SnakList` class does have a dedicated `addSnak`, and only this should be used to add snaks.

This is the only user of this method. This block us from removing the abstract base class, see https://github.com/wmde/WikibaseDataModel/pull/702.