### PR TITLE
[DNM] Remove confusing newEntity(De)Serializer methods

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -4,7 +4,6 @@ namespace Wikibase\DataModel;
 
 use Deserializers\Deserializer;
 use Deserializers\DispatchableDeserializer;
-use Deserializers\DispatchingDeserializer;
 use Wikibase\DataModel\Deserializers\AliasGroupListDeserializer;
 use Wikibase\DataModel\Deserializers\EntityIdDeserializer;
 use Wikibase\DataModel\Deserializers\ItemDeserializer;
@@ -51,18 +50,6 @@ class DeserializerFactory {
 	) {
 		$this->dataValueDeserializer = $dataValueDeserializer;
 		$this->entityIdParser = $entityIdParser;
-	}
-
-	/**
-	 * Returns a Deserializer that can deserialize Item and Property objects.
-	 *
-	 * @return DispatchableDeserializer
-	 */
-	public function newEntityDeserializer() {
-		return new DispatchingDeserializer( array(
-			$this->newItemDeserializer(),
-			$this->newPropertyDeserializer()
-		) );
 	}
 
 	/**

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -3,7 +3,6 @@
 namespace Wikibase\DataModel;
 
 use InvalidArgumentException;
-use Serializers\DispatchingSerializer;
 use Serializers\Serializer;
 use Wikibase\DataModel\Serializers\AliasGroupListSerializer;
 use Wikibase\DataModel\Serializers\AliasGroupSerializer;
@@ -91,18 +90,6 @@ class SerializerFactory {
 	 */
 	private function shouldSerializeReferenceSnaksWithHash() {
 		return !(bool)( $this->options & self::OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH );
-	}
-
-	/**
-	 * Returns a Serializer that can serialize Item and Property objects.
-	 *
-	 * @return Serializer
-	 */
-	public function newEntitySerializer() {
-		return new DispatchingSerializer( array(
-			$this->newItemSerializer(),
-			$this->newPropertySerializer()
-		) );
 	}
 
 	/**

--- a/tests/integration/EntityDeserializationCompatibilityTest.php
+++ b/tests/integration/EntityDeserializationCompatibilityTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wikibase\DataModel;
 
 use DataValues\Deserializers\DataValueDeserializer;
 use Deserializers\Deserializer;
+use Deserializers\DispatchingDeserializer;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -36,7 +37,10 @@ class EntityDeserializationCompatibilityTest extends \PHPUnit_Framework_TestCase
 			new BasicEntityIdParser()
 		);
 
-		$this->deserializer = $deserializerFactory->newEntityDeserializer();
+		$this->deserializer = new DispatchingDeserializer( [
+			$deserializerFactory->newItemDeserializer(),
+			$deserializerFactory->newPropertyDeserializer(),
+		] );
 	}
 
 	/**

--- a/tests/unit/DeserializerFactoryTest.php
+++ b/tests/unit/DeserializerFactoryTest.php
@@ -26,19 +26,6 @@ class DeserializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( true, 'No exception occurred during deserialization' );
 	}
 
-	public function testNewEntityDeserializer() {
-		$this->assertTrue( $this->buildDeserializerFactory()->newEntityDeserializer()->isDeserializerFor(
-			array(
-				'type' => 'item'
-			)
-		) );
-		$this->assertTrue( $this->buildDeserializerFactory()->newEntityDeserializer()->isDeserializerFor(
-			array(
-				'type' => 'property'
-			)
-		) );
-	}
-
 	public function testNewItemDeserializer() {
 		$this->assertDeserializesWithoutException(
 			$this->buildDeserializerFactory()->newItemDeserializer(),

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -36,18 +36,6 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( true, 'No exception occurred during serialization' );
 	}
 
-	public function testNewEntitySerializer() {
-		$this->assertSerializesWithoutException(
-			$this->buildSerializerFactory()->newEntitySerializer(),
-			new Item()
-		);
-
-		$this->assertSerializesWithoutException(
-			$this->buildSerializerFactory()->newEntitySerializer(),
-			Property::newFromType( 'string' )
-		);
-	}
-
 	public function testNewItemSerializer() {
 		$this->assertSerializesWithoutException(
 			$this->buildSerializerFactory()->newItemSerializer(),


### PR DESCRIPTION
My original suggestion was to rename this instead of removing it, but this is more or less the same than removing it and reintroducing a new method with a better name when we need it. It looks like we are not gonna need it.

Currently these two methods are still used in a handful of tests. In all these cases it can easily be replaced with either a DispatchingDeserializer, or by splitting the test cases just as I did it in this patch.

[Bug: T160436](https://phabricator.wikimedia.org/T160436)