### PR TITLE
Remove auto-generated @param-only PHPDoc blocks that add zero information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 matrix:
   fast_finish: true
   include:

--- a/src/Deserializers/EntityIdDeserializer.php
+++ b/src/Deserializers/EntityIdDeserializer.php
@@ -21,9 +21,6 @@ class EntityIdDeserializer implements Deserializer {
 	 */
 	private $entityIdParser;
 
-	/**
-	 * @param EntityIdParser $entityIdParser
-	 */
 	public function __construct( EntityIdParser $entityIdParser ) {
 		$this->entityIdParser = $entityIdParser;
 	}

--- a/src/Deserializers/ItemDeserializer.php
+++ b/src/Deserializers/ItemDeserializer.php
@@ -47,13 +47,6 @@ class ItemDeserializer extends TypedObjectDeserializer {
 	 */
 	private $siteLinkDeserializer;
 
-	/**
-	 * @param Deserializer $entityIdDeserializer
-	 * @param Deserializer $termListDeserializer
-	 * @param Deserializer $aliasGroupListDeserializer
-	 * @param Deserializer $statementListDeserializer
-	 * @param Deserializer $siteLinkDeserializer
-	 */
 	public function __construct(
 		Deserializer $entityIdDeserializer,
 		Deserializer $termListDeserializer,

--- a/src/Deserializers/PropertyDeserializer.php
+++ b/src/Deserializers/PropertyDeserializer.php
@@ -40,12 +40,6 @@ class PropertyDeserializer extends TypedObjectDeserializer {
 	 */
 	private $statementListDeserializer;
 
-	/**
-	 * @param Deserializer $entityIdDeserializer
-	 * @param Deserializer $termListDeserializer
-	 * @param Deserializer $aliasGroupListDeserializer
-	 * @param Deserializer $statementListDeserializer
-	 */
 	public function __construct(
 		Deserializer $entityIdDeserializer,
 		Deserializer $termListDeserializer,

--- a/src/Deserializers/ReferenceDeserializer.php
+++ b/src/Deserializers/ReferenceDeserializer.php
@@ -22,9 +22,6 @@ class ReferenceDeserializer implements DispatchableDeserializer {
 	 */
 	private $snaksDeserializer;
 
-	/**
-	 * @param Deserializer $snaksDeserializer
-	 */
 	public function __construct( Deserializer $snaksDeserializer ) {
 		$this->snaksDeserializer = $snaksDeserializer;
 	}

--- a/src/Deserializers/ReferenceListDeserializer.php
+++ b/src/Deserializers/ReferenceListDeserializer.php
@@ -20,9 +20,6 @@ class ReferenceListDeserializer implements Deserializer {
 	 */
 	private $referenceDeserializer;
 
-	/**
-	 * @param Deserializer $referenceDeserializer
-	 */
 	public function __construct( Deserializer $referenceDeserializer ) {
 		$this->referenceDeserializer = $referenceDeserializer;
 	}

--- a/src/Deserializers/SiteLinkDeserializer.php
+++ b/src/Deserializers/SiteLinkDeserializer.php
@@ -22,9 +22,6 @@ class SiteLinkDeserializer implements Deserializer {
 	 */
 	private $entityIdDeserializer;
 
-	/**
-	 * @param Deserializer $entityIdDeserializer
-	 */
 	public function __construct( Deserializer $entityIdDeserializer ) {
 		$this->entityIdDeserializer = $entityIdDeserializer;
 	}

--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -34,10 +34,6 @@ class SnakDeserializer implements DispatchableDeserializer {
 	 */
 	private $entityIdDeserializer;
 
-	/**
-	 * @param Deserializer $dataValueDeserializer
-	 * @param Deserializer $entityIdDeserializer
-	 */
 	public function __construct(
 		Deserializer $dataValueDeserializer,
 		Deserializer $entityIdDeserializer

--- a/src/Deserializers/SnakListDeserializer.php
+++ b/src/Deserializers/SnakListDeserializer.php
@@ -21,9 +21,6 @@ class SnakListDeserializer implements Deserializer {
 	 */
 	private $snakDeserializer;
 
-	/**
-	 * @param Deserializer $snakDeserializer
-	 */
 	public function __construct( Deserializer $snakDeserializer ) {
 		$this->snakDeserializer = $snakDeserializer;
 	}

--- a/src/Deserializers/StatementListDeserializer.php
+++ b/src/Deserializers/StatementListDeserializer.php
@@ -21,9 +21,6 @@ class StatementListDeserializer implements Deserializer {
 	 */
 	private $statementDeserializer;
 
-	/**
-	 * @param Deserializer $statementDeserializer
-	 */
 	public function __construct( Deserializer $statementDeserializer ) {
 		$this->statementDeserializer = $statementDeserializer;
 	}

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -22,9 +22,6 @@ class TermListDeserializer implements Deserializer {
 	 */
 	private $termDeserializer;
 
-	/**
-	 * @param Deserializer $termDeserializer
-	 */
 	public function __construct( Deserializer $termDeserializer ) {
 		$this->termDeserializer = $termDeserializer;
 	}

--- a/src/Serializers/PropertySerializer.php
+++ b/src/Serializers/PropertySerializer.php
@@ -33,11 +33,6 @@ class PropertySerializer implements DispatchableSerializer {
 	 */
 	private $statementListSerializer;
 
-	/**
-	 * @param Serializer $termListSerializer
-	 * @param Serializer $aliasGroupListSerializer
-	 * @param Serializer $statementListSerializer
-	 */
 	public function __construct(
 		Serializer $termListSerializer,
 		Serializer $aliasGroupListSerializer,

--- a/src/Serializers/ReferenceListSerializer.php
+++ b/src/Serializers/ReferenceListSerializer.php
@@ -21,9 +21,6 @@ class ReferenceListSerializer implements DispatchableSerializer {
 	 */
 	private $referenceSerializer;
 
-	/**
-	 * @param Serializer $referenceSerializer
-	 */
 	public function __construct( Serializer $referenceSerializer ) {
 		$this->referenceSerializer = $referenceSerializer;
 	}

--- a/src/Serializers/ReferenceSerializer.php
+++ b/src/Serializers/ReferenceSerializer.php
@@ -23,9 +23,6 @@ class ReferenceSerializer implements DispatchableSerializer {
 	 */
 	private $snaksSerializer;
 
-	/**
-	 * @param Serializer $snaksSerializer
-	 */
 	public function __construct( Serializer $snaksSerializer ) {
 		$this->snaksSerializer = $snaksSerializer;
 	}

--- a/src/Serializers/StatementSerializer.php
+++ b/src/Serializers/StatementSerializer.php
@@ -39,11 +39,6 @@ class StatementSerializer implements DispatchableSerializer {
 	 */
 	private $referencesSerializer;
 
-	/**
-	 * @param Serializer $mainSnakSerializer
-	 * @param Serializer $qualifierSnaksSerializer
-	 * @param Serializer $referencesSerializer
-	 */
 	public function __construct(
 		Serializer $mainSnakSerializer,
 		Serializer $qualifierSnaksSerializer,

--- a/src/Serializers/TypedSnakSerializer.php
+++ b/src/Serializers/TypedSnakSerializer.php
@@ -20,9 +20,6 @@ class TypedSnakSerializer implements Serializer {
 	 */
 	private $snakSerializer;
 
-	/**
-	 * @param Serializer $snakSerializer
-	 */
 	public function __construct( Serializer $snakSerializer ) {
 		$this->snakSerializer = $snakSerializer;
 	}

--- a/tests/integration/ReferencesSerializationRoundtripTest.php
+++ b/tests/integration/ReferencesSerializationRoundtripTest.php
@@ -56,10 +56,6 @@ class ReferencesSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	/**
-	 * @param ReferenceList $expected
-	 * @param ReferenceList $actual
-	 */
 	public function assertReferenceListEquals( ReferenceList $expected, ReferenceList $actual ) {
 		$this->assertTrue( $actual->equals( $expected ), 'The two ReferenceList are different' );
 	}

--- a/tests/unit/Deserializers/ReferenceListDeserializerTest.php
+++ b/tests/unit/Deserializers/ReferenceListDeserializerTest.php
@@ -79,10 +79,6 @@ class ReferenceListDeserializerTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	/**
-	 * @param ReferenceList $expected
-	 * @param ReferenceList $actual
-	 */
 	public function assertReferenceListEquals( ReferenceList $expected, ReferenceList $actual ) {
 		$this->assertTrue( $actual->equals( $expected ), 'The two ReferenceList are different' );
 	}


### PR DESCRIPTION
This patch removes auto-generated PHPDoc blocks that contain nothing but a sequence of `@param` lines that *literally* repeat what the function header below contains. These blocks add zero additional information, but clutter the code and need to be maintained. This patch does not touch PHPDoc blocks when one of the `@param` lines contains an actual comment behind the variable name, or when one of the types is not a class name.

See https://gerrit.wikimedia.org/r/360814 for the same patch in the Wikibase.git code base.