### PR TITLE
Remove non-standard Composer commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,19 +59,15 @@
 	},
 	"scripts": {
 		"test": [
-			"composer validate --no-interaction",
-			"vendor/bin/phpunit"
+			"@validate --no-interaction",
+			"phpunit"
 		],
 		"ci": [
-			"@test",
-			"@cs"
+			"@cs",
+			"@test"
 		],
 		"cs": [
-			"@phpcs"
-		],
-		"phpcs": [
-			"phpcs -ps"
+			"phpcs -p -s"
 		]
-
 	}
 }


### PR DESCRIPTION
I'm reducing the confusing number of Composer commands to "cs", "test", and "ci". Usually, PHPCS is executed before PHPUnit. This patch also makes sure this order is consistent.