### PR TITLE
Merge options to use snak hashes into one

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,13 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.5.0 (dev)
+
+* Deprecated `SerializerFactory` options
+  `OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH`,
+  `OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH` and
+  `OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH`,
+  and added `OPTION_SERIALIZE_SNAKS_WITHOUT_HASH` instead
+
 ## 2.4.0 (2017-03-16)
 
 * Added compatibility with Wikibase DataModel 7.x

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -37,17 +37,17 @@ class SerializerFactory {
 	const OPTION_OBJECTS_FOR_MAPS = 1;
 	/**
 	 * @since 1.7.0
-	 * @deprecated use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+	 * @deprecated since 2.5 use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
 	 */
 	const OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH = 2;
 	/**
 	 * @since 1.7.0
-	 * @deprecated use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+	 * @deprecated since 2.5 use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
 	 */
 	const OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH = 4;
 	/**
 	 * @since 1.7.0
-	 * @deprecated use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+	 * @deprecated since 2.5 use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
 	 */
 	const OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH = 8;
 	/**

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -35,10 +35,29 @@ class SerializerFactory {
 	const OPTION_DEFAULT = 0;
 	/** @since 1.2.0 */
 	const OPTION_OBJECTS_FOR_MAPS = 1;
-	/** @since 1.7.0 */
+	/**
+	 * @since 1.7.0
+	 * @deprecated use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+	 */
 	const OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH = 2;
+	/**
+	 * @since 1.7.0
+	 * @deprecated use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+	 */
 	const OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH = 4;
+	/**
+	 * @since 1.7.0
+	 * @deprecated use OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+	 */
 	const OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH = 8;
+	/**
+	 * Omit hashes when serializing snaks.
+	 * @since 2.5.0
+	 */
+	const OPTION_SERIALIZE_SNAKS_WITHOUT_HASH = 14; /* =
+		self::OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH |
+		self::OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH |
+		self::OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH; */
 
 	/**
 	 * @var int

--- a/tests/unit/SerializerFactoryTest.php
+++ b/tests/unit/SerializerFactoryTest.php
@@ -158,4 +158,15 @@ class SerializerFactoryTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testSerializeSnaksWithoutHashConstant() {
+		$this->assertSame(
+			// expected:
+			SerializerFactory::OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH |
+			SerializerFactory::OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH |
+			SerializerFactory::OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH,
+			// actual:
+			SerializerFactory::OPTION_SERIALIZE_SNAKS_WITHOUT_HASH
+		);
+	}
+
 }


### PR DESCRIPTION
Suppressing snak hashes was initially added as a single option in 656398540f, but then split up into three options in 679774d120, since the previous lib serializer included qualifier hashes but not main snak or reference hashes, and the goal was to migrate from that serializer to this one with absolutely no change in the output. Now that this migration is done, we can merge the three options into one again, since it’s hardly useful to have snak hashes for some snaks but not others: either include all hashes, or omit all of them.

This is implemented as an extra constant, which is the bitwise union of the three existing ones, for backwards compatibility. With the next major release, the three old options should be removed and the single option made functional instead (with a single method shouldSerializeSnaksWithHash()).

---

> With the next major release, the three old options should be removed

Is there a convenient place in this repository to note this down so we don’t forget it? Should I create an issue with milestone 3.0.0?