### PR TITLE
Release 2.6.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Wikibase DataModel Serialization release notes
 
+## 2.6.0 (2017-09-15)
+
+* Added compatibility with DataValues Number 0.9
+
 ## 2.5.0 (2017-08-30)
 
 * Removed MediaWiki integration files
@@ -7,8 +11,8 @@
 * Deprecated `SerializerFactory` options
   `OPTION_SERIALIZE_MAIN_SNAKS_WITHOUT_HASH`,
   `OPTION_SERIALIZE_QUALIFIER_SNAKS_WITHOUT_HASH` and
-  `OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH`,
-  and added `OPTION_SERIALIZE_SNAKS_WITHOUT_HASH` instead
+  `OPTION_SERIALIZE_REFERENCE_SNAKS_WITHOUT_HASH`.
+* Added `SerializerFactory::OPTION_SERIALIZE_SNAKS_WITHOUT_HASH`.
 
 ## 2.4.0 (2017-03-16)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Wikibase DataModel Serialization release notes
 
-## 2.6.0 (2017-09-15)
+## 2.6.0 (2017-09-18)
 
 * Added compatibility with DataValues Number 0.9
 

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.5.x-dev"
+			"dev-master": "2.6.x-dev"
 		}
 	},
 	"scripts": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="WikibaseDataModelServices">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="120" />
+			<property name="lineLimit" value="108" />
 		</properties>
 	</rule>
 

--- a/tests/unit/Deserializers/StatementDeserializerTest.php
+++ b/tests/unit/Deserializers/StatementDeserializerTest.php
@@ -21,8 +21,8 @@ use Wikibase\DataModel\Statement\Statement;
 class StatementDeserializerTest extends DispatchableDeserializerTest {
 
 	protected function buildDeserializer() {
-		$snakDeserializerMock = $this->getMock( Deserializer::class );
-		$snakDeserializerMock->expects( $this->any() )
+		$snakDeserializer = $this->getMock( Deserializer::class );
+		$snakDeserializer->expects( $this->any() )
 			->method( 'deserialize' )
 			->with( $this->equalTo( [
 					'snaktype' => 'novalue',
@@ -30,8 +30,8 @@ class StatementDeserializerTest extends DispatchableDeserializerTest {
 			] ) )
 			->will( $this->returnValue( new PropertyNoValueSnak( 42 ) ) );
 
-		$snaksDeserializerMock = $this->getMock( Deserializer::class );
-		$snaksDeserializerMock->expects( $this->any() )
+		$snakListDeserializer = $this->getMock( Deserializer::class );
+		$snakListDeserializer->expects( $this->any() )
 			->method( 'deserialize' )
 			->with( $this->equalTo( [
 				'P42' => [
@@ -45,13 +45,17 @@ class StatementDeserializerTest extends DispatchableDeserializerTest {
 				new PropertyNoValueSnak( 42 )
 			] ) ) );
 
-		$referencesDeserializerMock = $this->getMock( Deserializer::class );
-		$referencesDeserializerMock->expects( $this->any() )
+		$referenceListDeserializer = $this->getMock( Deserializer::class );
+		$referenceListDeserializer->expects( $this->any() )
 			->method( 'deserialize' )
 			->with( $this->equalTo( [] ) )
 			->will( $this->returnValue( new ReferenceList() ) );
 
-		return new StatementDeserializer( $snakDeserializerMock, $snaksDeserializerMock, $referencesDeserializerMock );
+		return new StatementDeserializer(
+			$snakDeserializer,
+			$snakListDeserializer,
+			$referenceListDeserializer
+		);
 	}
 
 	public function deserializableProvider() {
@@ -353,7 +357,10 @@ class StatementDeserializerTest extends DispatchableDeserializerTest {
 			'type' => 'claim'
 		];
 
-		$this->assertEquals( $statement->getHash(), $statementDeserializer->deserialize( $serialization )->getHash() );
+		$this->assertSame(
+			$statement->getHash(),
+			$statementDeserializer->deserialize( $serialization )->getHash()
+		);
 	}
 
 	public function testQualifiersOrderDeserializationWithTypeError() {


### PR DESCRIPTION
Note that #222 should be in this release!

I used the opportunity to lower the line length a little bit, to a limit where I only had to touch two lines in a single file. I ended touching a few more lines because I decided to rename some variables (I found $snakDeserializerMock and $snaksDeserializerMock especially confusing – the only difference was an "s" in the middle of the variable name).