### PR TITLE
Stop using numeric entity IDs

### DIFF
--- a/tests/unit/Serializers/ItemSerializerTest.php
+++ b/tests/unit/Serializers/ItemSerializerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Wikibase\DataModel\Serializers;
 
 use Serializers\Serializer;
 use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Serializers\ItemSerializer;
 use Wikibase\DataModel\SiteLink;
@@ -119,8 +120,7 @@ class ItemSerializerTest extends DispatchableSerializerTest {
 			],
 		];
 
-		$entity = new Item();
-		$entity->setId( 42 );
+		$entity = new Item( new ItemId( 'Q42' ) );
 		$provider[] = [
 			[
 				'type' => 'item',

--- a/tests/unit/Serializers/PropertySerializerTest.php
+++ b/tests/unit/Serializers/PropertySerializerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Wikibase\DataModel\Serializers;
 use Serializers\Serializer;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Serializers\PropertySerializer;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Statement\StatementList;
@@ -115,8 +116,7 @@ class PropertySerializerTest extends DispatchableSerializerTest {
 			],
 		];
 
-		$property = Property::newFromType( 'string' );
-		$property->setId( 42 );
+		$property = new Property( new PropertyId( 'P42' ), null, 'string' );
 		$provider[] = [
 			[
 				'type' => 'property',


### PR DESCRIPTION
We are planning a release where setId does not accept integers any more. Code like this here should just not exist any more.