### PR TITLE
Document public getters to return Dispatchable(De)serializers

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -71,7 +71,7 @@ class DeserializerFactory {
 	 *
 	 * @since 2.1
 	 *
-	 * @return Deserializer
+	 * @return DispatchableDeserializer
 	 */
 	public function newItemDeserializer() {
 		return new ItemDeserializer(
@@ -88,7 +88,7 @@ class DeserializerFactory {
 	 *
 	 * @since 2.1
 	 *
-	 * @return Deserializer
+	 * @return DispatchableDeserializer
 	 */
 	public function newPropertyDeserializer() {
 		return new PropertyDeserializer(

--- a/src/SerializerFactory.php
+++ b/src/SerializerFactory.php
@@ -131,7 +131,7 @@ class SerializerFactory {
 	 *
 	 * @since 2.1
 	 *
-	 * @return Serializer
+	 * @return DispatchableSerializer
 	 */
 	public function newItemSerializer() {
 		return new ItemSerializer(
@@ -148,7 +148,7 @@ class SerializerFactory {
 	 *
 	 * @since 2.1
 	 *
-	 * @return Serializer
+	 * @return DispatchableSerializer
 	 */
 	public function newPropertySerializer() {
 		return new PropertySerializer(
@@ -186,7 +186,7 @@ class SerializerFactory {
 	 *
 	 * @since 1.4
 	 *
-	 * @return Serializer
+	 * @return DispatchableSerializer
 	 */
 	public function newStatementSerializer() {
 		return new StatementSerializer(


### PR DESCRIPTION
To know this is critical for external callers as well as internally. Look how the newEntityDeserializer method uses the return values from newItemDeserializer and newPropertyDeserializer: in a DispatchingDeserializer, which requires the values to be of type DispatchableDeserializer. Same is true for usages outside of this component. So this information is already public, just not documented properly.