### PR TITLE
Fix Alias/TermDeserializers failing on numeric array keys

### DIFF
--- a/src/Deserializers/AliasGroupListDeserializer.php
+++ b/src/Deserializers/AliasGroupListDeserializer.php
@@ -66,10 +66,7 @@ class AliasGroupListDeserializer implements Deserializer {
 			$aliases[] = $aliasSerialization['value'];
 		}
 
-		return new AliasGroup(
-			$languageCode,
-			$aliases
-		);
+		return new AliasGroup( (string)$languageCode, $aliases );
 	}
 
 	private function assertIsValidAliasSerialization( $serialization, $requestedLanguage ) {
@@ -109,7 +106,7 @@ class AliasGroupListDeserializer implements Deserializer {
 		array $serialization,
 		$requestedLanguage
 	) {
-		if ( $serialization['language'] !== $requestedLanguage ) {
+		if ( strcmp( $serialization['language'], $requestedLanguage ) !== 0 ) {
 			throw new DeserializationException(
 				'Deserialization of a value of the attribute language (actual)'
 					. ' that is not matching the language key (requested) is not supported: '

--- a/src/Deserializers/TermListDeserializer.php
+++ b/src/Deserializers/TermListDeserializer.php
@@ -66,7 +66,7 @@ class TermListDeserializer implements Deserializer {
 		array $serialization,
 		$requestedLanguage
 	) {
-		if ( $serialization['language'] !== $requestedLanguage ) {
+		if ( strcmp( $serialization['language'], $requestedLanguage ) !== 0 ) {
 			throw new DeserializationException(
 				'Deserialization of a value of the attribute language (actual)'
 					. ' that is not matching the language key (requested) is not supported: '

--- a/tests/unit/Deserializers/AliasGroupListDeserializerTest.php
+++ b/tests/unit/Deserializers/AliasGroupListDeserializerTest.php
@@ -87,6 +87,10 @@ class AliasGroupListDeserializerTest extends PHPUnit_Framework_TestCase {
 					[ 'language' => 'en', 'value' => 'B' ],
 				] ],
 			],
+			'Matching numeric keys' => [
+				new AliasGroupList( [ new AliasGroup( '8', [ 'Eight' ] ) ] ),
+				[ '8' => [ [ 'language' => '8', 'value' => 'Eight' ] ] ],
+			],
 		];
 	}
 

--- a/tests/unit/Deserializers/TermListDeserializerTest.php
+++ b/tests/unit/Deserializers/TermListDeserializerTest.php
@@ -89,6 +89,10 @@ class TermListDeserializerTest extends PHPUnit_Framework_TestCase {
 					'de' => [ 'language' => 'de', 'value' => 'Delama' ],
 				],
 			],
+			'Matching numeric keys' => [
+				new TermList( [ new Term( '8', 'Eight' ) ] ),
+				[ '8' => [ 'language' => '8', 'value' => 'Eight' ] ],
+			],
 		];
 	}
 


### PR DESCRIPTION
This is a bug because both the Term class as well as the AliasGroup class happily accept language codes that only consist of digits, e.g. `new Term( '8', 'Eight' )`. The problem is that PHP forcefully converts array keys to integers if they look like an integer, even if provided as a string. There is nothing that can be done to avoid this magic behavior.

This patch solves the problem by replacing `!==` with strcmp, which includes a type conversion back to string.

We found this while working on https://gerrit.wikimedia.org/r/378889.

This is not critical in production because language codes that are only made of numbers don't exist. But this is a bug no matter what.