### PR TITLE
Fix SnakDeserializer causing "Undefined index" errors

### DIFF
--- a/src/DeserializerFactory.php
+++ b/src/DeserializerFactory.php
@@ -169,7 +169,7 @@ class DeserializerFactory {
 	 * @return Deserializer
 	 */
 	public function newSnakDeserializer() {
-		return new SnakDeserializer( $this->dataValueDeserializer, $this->newEntityIdDeserializer() );
+		return new SnakDeserializer( $this->dataValueDeserializer );
 	}
 
 	/**

--- a/tests/unit/Deserializers/SnakDeserializerTest.php
+++ b/tests/unit/Deserializers/SnakDeserializerTest.php
@@ -24,17 +24,10 @@ use Wikibase\DataModel\Snak\PropertyValueSnak;
 class SnakDeserializerTest extends DispatchableDeserializerTest {
 
 	protected function buildDeserializer() {
-		$entityIdDeserializerMock = $this->getMock( Deserializer::class );
-		$entityIdDeserializerMock->expects( $this->any() )
-			->method( 'deserialize' )
-			->with( $this->equalTo( 'P42' ) )
-			->will( $this->returnValue( new PropertyId( 'P42' ) ) );
-
 		return new SnakDeserializer(
 			new DataValueDeserializer( [
 				'string' => StringValue::class,
-			] ),
-			$entityIdDeserializerMock
+			] )
 		);
 	}
 
@@ -150,12 +143,7 @@ class SnakDeserializerTest extends DispatchableDeserializerTest {
 	}
 
 	public function testDeserializePropertyIdFilterItemId() {
-		$entityIdDeserializerMock = $this->getMock( Deserializer::class );
-		$entityIdDeserializerMock->expects( $this->any() )
-			->method( 'deserialize' )
-			->with( $this->equalTo( 'Q42' ) )
-			->will( $this->returnValue( new ItemId( 'Q42' ) ) );
-		$deserializer = new SnakDeserializer( new DataValueDeserializer(), $entityIdDeserializerMock );
+		$deserializer = new SnakDeserializer( new DataValueDeserializer() );
 
 		$this->setExpectedException( InvalidAttributeException::class );
 		$deserializer->deserialize( [


### PR DESCRIPTION
* The fact that an UnDeserializableValue was constructed just *assuming* the "type" and "value" array elements are there was a bug. This code path is executed when the DataValueDeserializer fails, which includes the situation when one or both array elements are just missing.
* I'm also removing the awkward EntityIdDeserializer injection. This code path can not accept anything but PropertyIds. There was even a check for this. Why do we need to call an overly complex generic "EntityId" deserializer, if we know already what entity type we expect? Note this is not a breaking change because all this is declared "package-private".
* Also remove the unused "composer cs" command.

[Bug: T178651](https://phabricator.wikimedia.org/T178651)