### PR TITLE
Make compatible with serialization/serialization 4.x

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 * Improved documentation of `SerializerFactory::newEntitySerializer` as well as
   `DeserializerFactory::newEntityDeserializer`.
+* Added compatibility with Serialization 4.x
 
 ## 2.6.0 (2017-09-18)
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	"require": {
 		"php": ">=5.5.9",
 		"wikibase/data-model": "~7.0|~6.0|~5.0|~4.2",
-		"serialization/serialization": "~3.1",
+		"serialization/serialization": "~4.0|~3.1",
 		"data-values/serialization": "~1.0"
 	},
 	"require-dev": {
@@ -51,7 +51,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.6.x-dev"
+			"dev-master": "2.7.x-dev"
 		}
 	},
 	"scripts": {

--- a/tests/integration/SnakSerializationRoundtripTest.php
+++ b/tests/integration/SnakSerializationRoundtripTest.php
@@ -86,8 +86,15 @@ class SnakSerializationRoundtripTest extends \PHPUnit_Framework_TestCase {
 		$serialization = $serializer->serialize( $goodSnak );
 		$newSnak = $deserializer->deserialize( $serialization );
 
-		$badSnak = new PropertyValueSnak( 42, new UnDeserializableValue( 'Yay', 'string', '' ) );
-		$this->assertEquals( $badSnak, $newSnak );
+		/** @var PropertyValueSnak $newSnak */
+		$this->assertInstanceOf( PropertyValueSnak::class, $newSnak );
+		$this->assertSame( 'P42', $newSnak->getPropertyId()->getSerialization() );
+
+		/** @var UnDeserializableValue $newValue */
+		$newValue = $newSnak->getDataValue();
+		$this->assertInstanceOf( UnDeserializableValue::class, $newValue );
+		$this->assertSame( 'Yay', $newValue->getValue() );
+		$this->assertSame( 'string', $newValue->getTargetType() );
 	}
 
 }


### PR DESCRIPTION
This is the next step in updating the dependency tree that started here:
* https://github.com/wmde/Serialization/pull/21
* https://github.com/DataValues/Serialization/pull/35

I had to update one roundtrip test to make it compatible with both versions. Before, the error message was empty, which was a bug. I think this is worth it. The error message is not part of the actual value, and should not be considered in a roundtrip test.

Note there are quite a lot of pull requests open here, and (as always) it would be awesome if we yould include at least some of them into this release. I suggest these candidates:
* #241 fixes an actual bug that causes logspam.
* #240 is not critical for production but a bugfix anyway.
* #239 is also a bugfix. Callers already asume the returned objects are dispatchable.
* #242 just updates the PHPCS rule set.