### PR TITLE
SnakDeserializer: Use instanceof instead of EntityId::getEntityType

### DIFF
--- a/src/Deserializers/SnakDeserializer.php
+++ b/src/Deserializers/SnakDeserializer.php
@@ -14,7 +14,6 @@ use Deserializers\Exceptions\MissingTypeException;
 use Deserializers\Exceptions\UnsupportedTypeException;
 use Wikibase\DataModel\Entity\EntityIdParser;
 use Wikibase\DataModel\Entity\EntityIdParsingException;
-use Wikibase\DataModel\Entity\Property;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertySomeValueSnak;
@@ -150,7 +149,7 @@ class SnakDeserializer implements DispatchableDeserializer {
 		try {
 			$id = $this->propertyIdParser->parse( $serialization );
 
-			if ( $id->getEntityType() !== Property::ENTITY_TYPE ) {
+			if ( !( $id instanceof PropertyId ) ) {
 				throw new InvalidAttributeException(
 					'property',
 					$serialization,


### PR DESCRIPTION
This is faster, per:
https://github.com/wmde/WikibaseDataModelSerialization/pull/250#discussion_r241556843